### PR TITLE
Update 0.1.1.2

### DIFF
--- a/include/mcsm/data/global_option.h
+++ b/include/mcsm/data/global_option.h
@@ -43,12 +43,21 @@ namespace mcsm {
         std::string getDataPathPerOS();
     public:
         GlobalOption(const std::string& path, const std::string& name);
+        /**
+         * @brief No mcsm::Result needed
+        */
         ~GlobalOption();
 
         nlohmann::json load() const;
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         std::string getPath();
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         std::string getName();
 
         nlohmann::json getValue(const std::string& key) const;
@@ -57,6 +66,9 @@ namespace mcsm {
 
         bool exists() const override;
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         bool isGlobal() const override;
 
         mcsm::Result save(const nlohmann::json& jsonData) const;

--- a/include/mcsm/data/option.h
+++ b/include/mcsm/data/option.h
@@ -39,13 +39,25 @@ namespace mcsm {
 
         bool createDirectories(std::string const &dirName, std::error_code &err) const;
     public:
+        /**
+         * @brief No mcsm::Result needed
+        */
         Option(const std::string& path, const std::string& name);
+        /**
+         * @brief No mcsm::Result needed
+        */
         ~Option();
 
         nlohmann::json load() const;
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         std::string getPath();
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         std::string getName();
 
         nlohmann::json getValue(const std::string& key) const;
@@ -54,6 +66,9 @@ namespace mcsm {
 
         bool exists() const override;
 
+        /**
+         * @brief No mcsm::Result needed
+        */
         bool isGlobal() const override;
 
         mcsm::Result save(const nlohmann::json& jsonData) const;

--- a/include/mcsm/data/options/modded/fabric_server_option.h
+++ b/include/mcsm/data/options/modded/fabric_server_option.h
@@ -27,6 +27,8 @@ namespace mcsm {
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option, const std::string& path, const std::string& optionPath);
 
+        mcsm::Result update();
+
         std::string getServerJarBuild() const;
         mcsm::Result setServerJarBuild(const std::string& build);
 
@@ -49,6 +51,9 @@ namespace mcsm {
 
         std::string getServerJarFile() const;
         mcsm::Result setServerJarFile(const std::string& name);
+
+        bool doesAutoUpdate() const;
+        mcsm::Result setAutoUpdate(const bool& update);
         
         std::shared_ptr<mcsm::Server> getServer() const;
     };

--- a/include/mcsm/data/options/server_option.h
+++ b/include/mcsm/data/options/server_option.h
@@ -50,6 +50,8 @@ namespace mcsm {
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option, const std::string& path, const std::string& optionPath);
 
+        mcsm::Result update(const std::string& path, const std::string& optionPath);
+
         bool exists();
 
         std::string getServerName() const;
@@ -68,6 +70,9 @@ namespace mcsm {
 
         std::string getServerJarBuild() const;
         mcsm::Result setServerJarBuild(const std::string& build);
+
+        bool doesAutoUpdate() const;
+        mcsm::Result setAutoUpdate(const bool& update);
 
         std::shared_ptr<mcsm::Server> getServer() const;
     };

--- a/include/mcsm/jvm/java_detection.h
+++ b/include/mcsm/jvm/java_detection.h
@@ -31,6 +31,9 @@ SOFTWARE.
 #include <mcsm/util/os/os_detection.h>
 
 namespace mcsm {
+    /**
+     * @brief No mcsm::Result needed
+     */
     std::string getJavaFromHome();
     std::string getJavaFromPath();
 

--- a/include/mcsm/server/type/base/vanilla_server.h
+++ b/include/mcsm/server/type/base/vanilla_server.h
@@ -34,6 +34,7 @@ namespace mcsm {
     class VanillaServer : public mcsm::Server, public mcsm::Downloadable {
     private:
         std::unique_ptr<std::map<const std::string, const std::string>> versions;
+        [[deprecated]]
         mcsm::Result init();
         std::string getVersionObject(const std::string& ver) const;
         std::string getServerJarURL(const std::string& ver) const;

--- a/include/mcsm/server/type/base/vanilla_server.h
+++ b/include/mcsm/server/type/base/vanilla_server.h
@@ -35,7 +35,7 @@ namespace mcsm {
     private:
         std::unique_ptr<std::map<const std::string, const std::string>> versions;
         mcsm::Result init();
-        std::string getVersionURL(const std::string& ver) const;
+        std::string getVersionObject(const std::string& ver) const;
     public:
         VanillaServer();
         ~VanillaServer();

--- a/include/mcsm/server/type/base/vanilla_server.h
+++ b/include/mcsm/server/type/base/vanilla_server.h
@@ -36,6 +36,7 @@ namespace mcsm {
         std::unique_ptr<std::map<const std::string, const std::string>> versions;
         mcsm::Result init();
         std::string getVersionObject(const std::string& ver) const;
+        std::string getServerJarURL(const std::string& ver) const;
     public:
         VanillaServer();
         ~VanillaServer();

--- a/include/mcsm/server/type/base/vanilla_server.h
+++ b/include/mcsm/server/type/base/vanilla_server.h
@@ -35,6 +35,7 @@ namespace mcsm {
     private:
         std::unique_ptr<std::map<const std::string, const std::string>> versions;
         mcsm::Result init();
+        std::string getVersionURL(const std::string& ver) const;
     public:
         VanillaServer();
         ~VanillaServer();

--- a/include/mcsm/server/type/bukkit/paper_server.h
+++ b/include/mcsm/server/type/bukkit/paper_server.h
@@ -64,6 +64,7 @@ namespace mcsm {
 
         mcsm::Result update();
         mcsm::Result update(const std::string& optionPath);
+        mcsm::Result update(const std::string& path, const std::string& optionPath);
     };
 }
 

--- a/include/mcsm/server/type/bukkit/purpur_server.h
+++ b/include/mcsm/server/type/bukkit/purpur_server.h
@@ -64,6 +64,7 @@ namespace mcsm {
         
         mcsm::Result update();
         mcsm::Result update(const std::string& optionPath);
+        mcsm::Result update(const std::string& path, const std::string& optionPath);
     };
 }
 

--- a/include/mcsm/server/type/modded/fabric_server.h
+++ b/include/mcsm/server/type/modded/fabric_server.h
@@ -67,6 +67,7 @@ namespace mcsm {
         
         mcsm::Result update();
         mcsm::Result update(const std::string& optionPath);
+        mcsm::Result update(const std::string& path, const std::string& optionPath);
     };
 }
 

--- a/src/command/util/help_command.cpp
+++ b/src/command/util/help_command.cpp
@@ -34,7 +34,7 @@ void mcsm::HelpCommand::execute(const std::vector<std::string>& args){
         }
     }else{
         if(!mcsm::CommandManager::hasCommand(args[0])){
-            std::cout << "Unknown command \"" << args[0] << "\". Type 'mcsm help' for list of commands." << "\n";
+            std::cout << "Unknown command \"" << args[0] << "\". Type 'mcsm help' for a list of commands." << "\n";
             std::exit(1);
         }
         std::unique_ptr<mcsm::Command> command = mcsm::CommandManager::getCommand(args[0]);

--- a/src/data/global_option.cpp
+++ b/src/data/global_option.cpp
@@ -132,7 +132,6 @@ bool mcsm::GlobalOption::exists() const {
 }
 
 bool mcsm::GlobalOption::isGlobal() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return true;
 }
 
@@ -178,11 +177,9 @@ mcsm::Result mcsm::GlobalOption::reset() const {
 }
 
 std::string mcsm::GlobalOption::getName(){
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return this->name;
 }
 
 std::string mcsm::GlobalOption::getPath(){
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return this->path;
 }

--- a/src/data/option.cpp
+++ b/src/data/option.cpp
@@ -104,7 +104,6 @@ bool mcsm::Option::exists() const {
 }
 
 bool mcsm::Option::isGlobal() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return false;
 }
 
@@ -150,11 +149,9 @@ mcsm::Result mcsm::Option::reset() const {
 }
 
 std::string mcsm::Option::getName(){
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return this->name;
 }
 
 std::string mcsm::Option::getPath(){
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return this->path;
 }

--- a/src/data/options/modded/fabric_server_option.cpp
+++ b/src/data/options/modded/fabric_server_option.cpp
@@ -227,6 +227,9 @@ mcsm::Result mcsm::FabricServerOption::create(const std::string& name, mcsm::Jvm
     
     mcsm::Result res6 = option.setValue("server_build", "latest");
     if(!res6.isSuccess()) return res6;
+
+    mcsm::Result res12 = option.setValue("auto_update", true);
+    if(!res12.isSuccess()) return res12;
     
     mcsm::Result res7 = option.setValue("type", this->server->getTypeAsString());
     if(!res7.isSuccess()) return res7;
@@ -610,6 +613,36 @@ std::string mcsm::FabricServerOption::getServerJarFile() const{
 mcsm::Result mcsm::FabricServerOption::setServerJarFile(const std::string& name){
     mcsm::Option option(this->path, "server");
     return option.setValue("server_jar", name);
+}
+
+bool mcsm::FabricServerOption::doesAutoUpdate() const {
+    mcsm::Option option(this->path, "server");
+    bool optExists = option.exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+    if(!optExists){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        return "";
+    }
+
+    nlohmann::json value = option.getValue("auto_update");
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+
+    if(value == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonNotFound("\"auto_update\"", option.getName())});
+        return "";
+    }
+    if(!value.is_boolean()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonWrongType("\"auto_update\"", "boolean")});
+        return "";
+    }
+
+    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return value;
+}
+
+mcsm::Result mcsm::FabricServerOption::setAutoUpdate(const bool& update){
+    mcsm::Option option(this->path, "server");
+    return option.setValue("auto_update", update);
 }
 
 std::shared_ptr<mcsm::Server> mcsm::FabricServerOption::getServer() const {

--- a/src/data/options/server_option.cpp
+++ b/src/data/options/server_option.cpp
@@ -305,7 +305,8 @@ mcsm::Result mcsm::ServerOption::start(std::unique_ptr<mcsm::JvmOption> option, 
     return res2;
 }
 
-mcsm::Result mcsm::ServerOption::update(const std::string& path, const std::string& optionPath){
+//WIP
+mcsm::Result mcsm::ServerOption::update(const std::string& /* path */, const std::string& optionPath){
     bool fileExists = mcsm::fileExists(optionPath + "/server.json");
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
@@ -329,7 +330,8 @@ mcsm::Result mcsm::ServerOption::update(const std::string& path, const std::stri
         }
     }
     
-    
+    mcsm::Result res1({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return res1;
 }
 
 bool mcsm::ServerOption::exists(){

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,7 +45,7 @@ void mcsm::init::initCommands(const std::string& version){
     mcsm::CommandManager::init();
 
     // Register commands to CommandManager
-    std::unique_ptr<mcsm::VersionCommand> versionCommand = std::make_unique<mcsm::VersionCommand>("version", "Returns version information about this program.", version);
+    std::unique_ptr<mcsm::VersionCommand> versionCommand = std::make_unique<mcsm::VersionCommand>("version", "Returns the version information about this program.", version);
     versionCommand->addAlias("ver");
     mcsm::CommandManager::addCommand(std::move(versionCommand));
 
@@ -81,7 +81,7 @@ void mcsm::init::initCommands(const std::string& version){
     jvmOptionEditCommand->addAlias("editjvmprofile");
     mcsm::CommandManager::addCommand(std::move(jvmOptionEditCommand));
 
-    std::unique_ptr<mcsm::StartServerCommand> startServerCommand = std::make_unique<mcsm::StartServerCommand>("start", "Starts a configured server.");
+    std::unique_ptr<mcsm::StartServerCommand> startServerCommand = std::make_unique<mcsm::StartServerCommand>("start", "Starts the configured server.");
     startServerCommand->addAlias("startServer");
     startServerCommand->addAlias("startserver");
     mcsm::CommandManager::addCommand(std::move(startServerCommand));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,12 @@ SOFTWARE.
 const std::string version = "0.1.1.2";
 
 int main(int argc, char *argv[]){
+    /**
+     * TODO
+     * Implement mcsm update command and "auto_update" option in server config.
+     * Implement different path and option path in server classes' update method
+     */
+
     //libssh2 : cmake -B ./build -DBUILD_SHARED_LIBS=OFF -DOPENSSL_USE_STATIC_LIBS=ON -DZLIB_USE_STATIC_LIBS=ON -DENABLE_ZLIB_COMPRESSION=ON -DCRYPTO_BACKEND=OpenSSL
     //libgit2 : cmake -B ./build -DBUILD_SHARED_LIBS=OFF -DOPENSSL_USE_STATIC_LIBS=ON -DZLIB_USE_STATIC_LIBS=ON
     //libcurl-linux : cmake -B ./build -DBUILD_SHARED_LIBS=OFF -DOPENSSL_USE_STATIC_LIBS=ON -DZLIB_USE_STATIC_LIBS=ON

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,7 @@ const std::string version = "0.1.1.2";
 int main(int argc, char *argv[]){
     /**
      * TODO
-     * Implement mcsm update command and "auto_update" option in server config.
-     * Implement different path and option path in server classes' update method
+     * Implement mcsm update command.
      */
 
     //libssh2 : cmake -B ./build -DBUILD_SHARED_LIBS=OFF -DOPENSSL_USE_STATIC_LIBS=ON -DZLIB_USE_STATIC_LIBS=ON -DENABLE_ZLIB_COMPRESSION=ON -DCRYPTO_BACKEND=OpenSSL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]){
 
     //If arguments exist but command is not found, prints message and exits
     if(!commandFound){
-        std::cerr << "Unknown command \"" << argv[1] << "\". " << "Type \'mcsm help\' for list of commands.\n";
+        std::cerr << "Unknown command \"" << argv[1] << "\". " << "Type \'mcsm help\' for a list of commands.\n";
         return 1;
     }
     

--- a/src/server/server_generator.cpp
+++ b/src/server/server_generator.cpp
@@ -234,11 +234,11 @@ std::shared_ptr<mcsm::Server> mcsm::server::detectServerType(const std::string& 
 
     if(server == "paper" || server == "papermc"){
         sPtr = std::make_shared<mcsm::PaperServer>();
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
+        //if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     }
     if(server == "purpur" || server == "purpurmc"){
         sPtr = std::make_shared<mcsm::PurpurServer>();
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
+        //if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     }
     if(server == "vanilla"){
         sPtr = std::make_shared<mcsm::VanillaServer>();
@@ -246,7 +246,7 @@ std::shared_ptr<mcsm::Server> mcsm::server::detectServerType(const std::string& 
     }
     if(server == "fabric" || server == "fabricmc"){
         sPtr = std::make_shared<mcsm::FabricServer>();
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
+        //if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     }
     if(sPtr == nullptr){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {

--- a/src/server/type/base/vanilla_server.cpp
+++ b/src/server/type/base/vanilla_server.cpp
@@ -151,6 +151,63 @@ std::string mcsm::VanillaServer::getVersionObject(const std::string& ver) const 
     return "";
 }
 
+std::string mcsm::VanillaServer::getServerJarURL(const std::string& ver) const {
+    std::string versionJson = getVersionObject(ver);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+    if(mcsm::isWhitespaceOrEmpty(versionJson)){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverUnsupportedVersion(ver)});
+        return "";
+    }
+    nlohmann::json version = nlohmann::json::parse(versionJson, nullptr, false);
+    if(version.is_discarded()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Parse of json failed. (Vanilla version object)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(version["type"] == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"type\" not found. (Vanilla version object)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(version["url"] == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"url\" not found. (Vanilla version object)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(!version["type"].is_string()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"type\" is not string. (Vanilla version object)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(!version["url"].is_string()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"url\" is not string. (Vanilla version object)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+
+    if(version["type"] == "old_beta" || version["type"] == "old_alpha"){
+        mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+            "No plans to support beta and alpha versions.",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+        }});
+        return "";
+    }
+
+    std::string url = version["url"];
+    std::string serverJson = mcsm::get(url);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+}
+
 std::vector<std::string> mcsm::VanillaServer::getAvailableVersions(){
     std::vector<std::string> vector;
     vector.reserve(this->versions->size());

--- a/src/server/type/base/vanilla_server.cpp
+++ b/src/server/type/base/vanilla_server.cpp
@@ -82,7 +82,7 @@ mcsm::Result mcsm::VanillaServer::init(){
     return res;
 }
 
-std::string mcsm::VanillaServer::getVersionURL(const std::string& ver) const {
+std::string mcsm::VanillaServer::getVersionObject(const std::string& ver) const {
     std::string jsonData = mcsm::get("https://launchermeta.mojang.com/mc/game/version_manifest.json");
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     

--- a/src/server/type/base/vanilla_server.cpp
+++ b/src/server/type/base/vanilla_server.cpp
@@ -87,7 +87,6 @@ std::string mcsm::VanillaServer::getVersionURL(const std::string& ver) const {
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     
     nlohmann::json data = nlohmann::json::parse(jsonData);
-    
     if(data.is_discarded()){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
             "Parse of json failed. (Vanilla version manifest)",
@@ -95,6 +94,7 @@ std::string mcsm::VanillaServer::getVersionURL(const std::string& ver) const {
         }});
         return "";  
     }
+
     // Check if "versions" array exists
     if(!data.contains("versions")){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {

--- a/src/server/type/base/vanilla_server.cpp
+++ b/src/server/type/base/vanilla_server.cpp
@@ -204,8 +204,72 @@ std::string mcsm::VanillaServer::getServerJarURL(const std::string& ver) const {
     }
 
     std::string url = version["url"];
+    //mcsm::info(url); //debug
     std::string serverJson = mcsm::get(url);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+    if(mcsm::isWhitespaceOrEmpty(versionJson)){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverUnsupportedVersion(ver)});
+        return "";
+    }
+
+    nlohmann::json serverData = nlohmann::json::parse(serverJson);
+    if(serverData.is_discarded()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Parse of json failed. (Vanilla version.json file).",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";  
+    }
+    nlohmann::json downloadsValue = serverData["downloads"];
+    if(downloadsValue == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"downloads\" not found. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(!downloadsValue.is_object()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"downloads\" not a json object. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+
+    nlohmann::json serverValue = downloadsValue["server"];
+    if(serverValue == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"server\" not found. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(!serverValue.is_object()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"server\" not a json object. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+
+    nlohmann::json serverJarURL = serverValue["url"];
+    if(serverJarURL == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"url\" not found. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+    if(!serverJarURL.is_string()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Value \"url\" not a string. (Vanilla version.json file)",
+            "Please report this to Github(https://github.com/dodoman8067/mcsm) if you believe that this is a software issue." 
+        }});
+        return "";
+    }
+
+    std::string finalReturnValue = serverJarURL;
+    return finalReturnValue;
 }
 
 std::vector<std::string> mcsm::VanillaServer::getAvailableVersions(){

--- a/src/server/type/base/vanilla_server.cpp
+++ b/src/server/type/base/vanilla_server.cpp
@@ -264,7 +264,7 @@ mcsm::Result mcsm::VanillaServer::start(mcsm::JvmOption& option, const std::stri
 }
 
 bool mcsm::VanillaServer::hasVersion(const std::string& version){
-    std::string ver = getVersionURL(version);
+    std::string ver = getVersionObject(version);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
     return !mcsm::isWhitespaceOrEmpty(ver);
 }

--- a/src/server/type/bukkit/paper_server.cpp
+++ b/src/server/type/bukkit/paper_server.cpp
@@ -290,7 +290,7 @@ mcsm::Result mcsm::PaperServer::start(mcsm::JvmOption& option, const std::string
         }
         
         if(doesUpdate){
-            mcsm::Result res = update(optionPath);
+            mcsm::Result res = update(path, optionPath);
             if(!res.isSuccess()) return res;
         }
     }
@@ -305,10 +305,21 @@ mcsm::Result mcsm::PaperServer::update(){
         return res;
     }
 
-    return update(path);
+    return update(path, path);
 }
 
 mcsm::Result mcsm::PaperServer::update(const std::string& optionPath){
+    std::string path = mcsm::getCurrentPath();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    return update(path, optionPath);
+}
+
+mcsm::Result mcsm::PaperServer::update(const std::string& path, const std::string& optionPath){
     // If you change the default build to specific build from latest build, it won't downgrade automatically. (You'll have to manually delete the server jarfile) This is an intented feature.
     mcsm::info("Checking updates...");
     mcsm::ServerDataOption sDataOpt(optionPath);
@@ -393,7 +404,7 @@ mcsm::Result mcsm::PaperServer::update(const std::string& optionPath){
         return res;
     }
 
-    bool fileExists = mcsm::fileExists(optionPath + "/" + jar);
+    bool fileExists = mcsm::fileExists(path + "/" + jar);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
         mcsm::Result res(resp.first, resp.second);
@@ -401,14 +412,14 @@ mcsm::Result mcsm::PaperServer::update(const std::string& optionPath){
     }
 
     if(fileExists){
-        mcsm::removeFile(optionPath + "/" + jar);
+        mcsm::removeFile(path + "/" + jar);
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);
             return res;
         }
     }
-    return download(version, optionPath, jar, optionPath);
+    return download(version, path, jar, optionPath);
 }
 
 bool mcsm::PaperServer::hasVersion(const std::string& version){

--- a/src/server/type/bukkit/paper_server.cpp
+++ b/src/server/type/bukkit/paper_server.cpp
@@ -34,6 +34,7 @@ int mcsm::PaperServer::getVersion(const std::string& ver) const {
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonParseFailedCannotBeModified()});
         return -1;
     }
+    if(json["builds"] == nullptr) return -1;
     if(json["builds"].is_array()){
         nlohmann::json builds = json["builds"];
         if(builds[json["builds"].size() - 1] == nullptr || !builds[json["builds"].size() - 1].is_number_integer()) return -1;
@@ -66,27 +67,22 @@ std::vector<std::string> mcsm::PaperServer::getAvailableVersions(){
     for(const std::string& s : mcsm::getMinecraftVersions()){
         versions.push_back(s);
     }
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return versions;
 }
 
 std::string mcsm::PaperServer::getSupportedVersions() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "1.8~";
 }
 
 std::string mcsm::PaperServer::getBasedServer() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "spigot";
 }
 
 std::string mcsm::PaperServer::getWebSite() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://papermc.io";
 }
 
 std::string mcsm::PaperServer::getGitHub() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://github.com/PaperMC/Paper";
 }
 

--- a/src/server/type/bukkit/paper_server.cpp
+++ b/src/server/type/bukkit/paper_server.cpp
@@ -282,8 +282,17 @@ mcsm::Result mcsm::PaperServer::start(mcsm::JvmOption& option, const std::string
         mcsm::Result res = download(sVer, path, jar, optionPath);
         if(!res.isSuccess()) return res;
     }else{
-        mcsm::Result res = update(optionPath);
-        if(!res.isSuccess()) return res;
+        bool doesUpdate = sOpt.doesAutoUpdate();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+        
+        if(doesUpdate){
+            mcsm::Result res = update(optionPath);
+            if(!res.isSuccess()) return res;
+        }
     }
     return Server::start(option, path, optionPath);
 }

--- a/src/server/type/bukkit/purpur_server.cpp
+++ b/src/server/type/bukkit/purpur_server.cpp
@@ -289,7 +289,7 @@ mcsm::Result mcsm::PurpurServer::start(mcsm::JvmOption& option, const std::strin
         }
         
         if(doesUpdate){
-            mcsm::Result res = update(optionPath);
+            mcsm::Result res = update(path, optionPath);
             if(!res.isSuccess()) return res;
         }
     }
@@ -304,10 +304,21 @@ mcsm::Result mcsm::PurpurServer::update(){
         return res;
     }
 
-    return update(path);
+    return update(path, path);
 }
 
 mcsm::Result mcsm::PurpurServer::update(const std::string& optionPath){
+    std::string path = mcsm::getCurrentPath();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    return update(path, optionPath);
+}
+
+mcsm::Result mcsm::PurpurServer::update(const std::string& path, const std::string& optionPath){
     // If you change the default build to specific build from latest build, it won't downgrade automatically. (You'll have to manually delete the server jarfile) This is an intented feature.
     mcsm::info("Checking updates...");
     mcsm::ServerDataOption sDataOpt(optionPath);
@@ -392,7 +403,7 @@ mcsm::Result mcsm::PurpurServer::update(const std::string& optionPath){
         return res;
     }
 
-    bool fileExists = mcsm::fileExists(optionPath + "/" + jar);
+    bool fileExists = mcsm::fileExists(path + "/" + jar);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
         mcsm::Result res(resp.first, resp.second);
@@ -400,14 +411,14 @@ mcsm::Result mcsm::PurpurServer::update(const std::string& optionPath){
     }
 
     if(fileExists){
-        mcsm::removeFile(optionPath + "/" + jar);
+        mcsm::removeFile(path + "/" + jar);
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);
             return res;
         }
     }
-    return download(version, optionPath, jar, optionPath);
+    return download(version, path, jar, optionPath);
 }
 
 bool mcsm::PurpurServer::hasVersion(const std::string& version){

--- a/src/server/type/bukkit/purpur_server.cpp
+++ b/src/server/type/bukkit/purpur_server.cpp
@@ -66,27 +66,22 @@ std::vector<std::string> mcsm::PurpurServer::getAvailableVersions(){
     for(const std::string& s : mcsm::getMinecraftVersions()){
         versions.push_back(s);
     }
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return versions;
 }
 
 std::string mcsm::PurpurServer::getSupportedVersions() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "1.14.1~";
 }
 
 std::string mcsm::PurpurServer::getBasedServer() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "pufferfish";
 }
 
 std::string mcsm::PurpurServer::getWebSite() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://purpurmc.org";
 }
 
 std::string mcsm::PurpurServer::getGitHub() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://github.com/PurpurMC/Purpur";
 }
 

--- a/src/server/type/bukkit/purpur_server.cpp
+++ b/src/server/type/bukkit/purpur_server.cpp
@@ -281,8 +281,17 @@ mcsm::Result mcsm::PurpurServer::start(mcsm::JvmOption& option, const std::strin
         mcsm::Result res = download(sVer, path, jar, optionPath);
         if(!res.isSuccess()) return res;
     }else{
-        mcsm::Result res = update(optionPath);
-        if(!res.isSuccess()) return res;
+        bool doesUpdate = sOpt.doesAutoUpdate();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+        
+        if(doesUpdate){
+            mcsm::Result res = update(optionPath);
+            if(!res.isSuccess()) return res;
+        }
     }
     return Server::start(option, path, optionPath);
 }

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -51,7 +51,7 @@ std::string mcsm::CustomServer::getFileLocation() const {
 
 mcsm::Result mcsm::CustomServer::setFileLocation(const std::string& location) {
     mcsm::Option option(".", "server");
-    option.setValue("jar_location", location);
+    return option.setValue("jar_location", location);
 }
 
 mcsm::Result mcsm::CustomServer::getFileFromLocation() {
@@ -64,6 +64,9 @@ mcsm::Result mcsm::CustomServer::getFileFromLocation() {
         mcsm::error("The following server jarfile location wasn't a vaild location : " + location);
         mcsm::error("Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue.");
     }
+
+    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return res;
 }
 
 bool mcsm::CustomServer::isFile(const std::string& location) const {

--- a/src/server/type/modded/fabric_server.cpp
+++ b/src/server/type/modded/fabric_server.cpp
@@ -599,8 +599,17 @@ mcsm::Result mcsm::FabricServer::start(mcsm::JvmOption& option, const std::strin
         mcsm::Result res = download(sVer, path, jar, optionPath);
         if(!res.isSuccess()) return res;
     }else{
-        mcsm::Result res = update(optionPath);
-        if(!res.isSuccess()) return res;
+        bool doesUpdate = sOpt.doesAutoUpdate();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+        
+        if(doesUpdate){
+            mcsm::Result res = update(optionPath);
+            if(!res.isSuccess()) return res;
+        }
     }
     return Server::start(option, path, optionPath);
 }

--- a/src/server/type/modded/fabric_server.cpp
+++ b/src/server/type/modded/fabric_server.cpp
@@ -607,7 +607,7 @@ mcsm::Result mcsm::FabricServer::start(mcsm::JvmOption& option, const std::strin
         }
         
         if(doesUpdate){
-            mcsm::Result res = update(optionPath);
+            mcsm::Result res = update(path, optionPath);
             if(!res.isSuccess()) return res;
         }
     }
@@ -622,10 +622,21 @@ mcsm::Result mcsm::FabricServer::update(){
         return res;
     }
 
-    return update(path);
+    return update(path, path);
 }
 
 mcsm::Result mcsm::FabricServer::update(const std::string& optionPath){
+    std::string path = mcsm::getCurrentPath();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    return update(path, optionPath);
+}
+
+mcsm::Result mcsm::FabricServer::update(const std::string& path, const std::string& optionPath){
     mcsm::FabricServerDataOption sDataOpt(optionPath);
     mcsm::Option opt(optionPath, "server");
     bool exists = opt.exists();
@@ -767,7 +778,7 @@ mcsm::Result mcsm::FabricServer::update(const std::string& optionPath){
         return res;
     }
 
-    bool fileExists = mcsm::fileExists(optionPath + "/" + jar);
+    bool fileExists = mcsm::fileExists(path + "/" + jar);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
         mcsm::Result res(resp.first, resp.second);
@@ -775,7 +786,7 @@ mcsm::Result mcsm::FabricServer::update(const std::string& optionPath){
     }
 
     if(fileExists){
-        mcsm::removeFile(optionPath + "/" + jar);
+        mcsm::removeFile(path + "/" + jar);
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);
@@ -783,7 +794,7 @@ mcsm::Result mcsm::FabricServer::update(const std::string& optionPath){
         }
     }
 
-    return download(sVer, loaderVer, installerVer, optionPath, jar, optionPath);
+    return download(sVer, loaderVer, installerVer, path, jar, optionPath);
 }
 
 bool mcsm::FabricServer::hasVersion(const std::string& version){

--- a/src/server/type/modded/fabric_server.cpp
+++ b/src/server/type/modded/fabric_server.cpp
@@ -76,27 +76,22 @@ std::vector<std::string> mcsm::FabricServer::getAvailableVersions(){
     for(const std::string& s : mcsm::getMinecraftVersions()){
         versions.push_back(s);
     }
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return versions;
 }
 
 std::string mcsm::FabricServer::getSupportedVersions() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "1.14~";
 }
 
 std::string mcsm::FabricServer::getBasedServer() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "vanilla";
 }
 
 std::string mcsm::FabricServer::getWebSite() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://fabricmc.net";
 }
 
 std::string mcsm::FabricServer::getGitHub() const {
-    mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return "https://github.com/FabricMC/fabric";
 }
 

--- a/src/util/mc/mc_utils.cpp
+++ b/src/util/mc/mc_utils.cpp
@@ -61,7 +61,9 @@ std::vector<std::string> mcsm::getMinecraftVersions(){
         "1.19.4",
         "1.20",
         "1.20.1",
-        "1.20.2"
+        "1.20.2",
+        "1.20.3",
+        "1.20.4"
     };
     return versions;
 }


### PR DESCRIPTION
Update 0.1.1.2

- Support different path and optionPath parameters in update() methods in server classes.
- Add "auto_update" option in server.json file. If it's false the program won't automatically check server updates when the server is starting. _Can be updated by mcsm update command if "server_build" option is "latest". (Will be implemented in 0.1.1.3)_
- Vanilla server jarfile download system is now based on Mojang website. It means the program will be able to download older versions such as 1.5.2 but keep in mind that you will receive no support.