### PR TITLE
0.1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-MCSM (MineCraft Server Manager) is a command-line program designed to manage Minecraft servers. Note that this project is still work in progress and it's not ready for production.
+MCSM (MineCraft Server Manager) is a command-line program designed to manage Minecraft servers. Note that there's a better option called Docker and I wouldn't recommend using this right now because this project is mostly for me leaning C++.
 
 ## Supported platforms
 

--- a/assets/resources.rc
+++ b/assets/resources.rc
@@ -4,16 +4,16 @@
 #define STRING_FILE_DESCRIPTION "Minecraft Server Manager"
 
 1 VERSIONINFO
-FILEVERSION 0,0,2,0
-PRODUCTVERSION 0,0,2,0
+FILEVERSION 0,1,1,3
+PRODUCTVERSION 0,1,1,3
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
         BLOCK "040904E4"
         BEGIN
             VALUE "FileDescription", STRING_FILE_DESCRIPTION
-            VALUE "FileVersion", "0,0,2,0"
-            VALUE "ProductVersion", "0.0.2.0"
+            VALUE "FileVersion", "0,1,1,3"
+            VALUE "ProductVersion", "0,1,1,3"
             VALUE "ProductName", STRING_FILE_DESCRIPTION
             VALUE "CompanyName", "dodoman8067\0"
             VALUE "LegalCopyright", "MIT license\0" 

--- a/include/mcsm/command/server/generate_server_command.h
+++ b/include/mcsm/command/server/generate_server_command.h
@@ -36,7 +36,8 @@ namespace mcsm {
         std::string getServerName(const std::vector<std::string>& args) const;
         std::string getServerVersion(const std::vector<std::string>& args) const;
         std::string getServerType(const std::vector<std::string>& args) const;
-        mcsm::SearchTarget getSearchTarget(const std::vector<std::string>& args);
+        mcsm::SearchTarget getSearchTarget(const std::vector<std::string>& args) const;
+        bool shouldSkipAutoUpdate(const std::vector<std::string>& args) const;
         std::unique_ptr<mcsm::JvmOption> searchOption(const mcsm::SearchTarget& target, const std::string& name);
         void detectServer(const std::vector<std::string>& args);
         inline bool isConfigured();

--- a/include/mcsm/data/options/jvm_option.h
+++ b/include/mcsm/data/options/jvm_option.h
@@ -40,9 +40,11 @@ namespace mcsm {
     private:
         std::unique_ptr<mcsm::Configurable> option;
         std::string name;
+        std::string workingDir;
     public:
         JvmOption(const std::string& name);
         JvmOption(const std::string& name, const SearchTarget& target);
+        JvmOption(const std::string& name, const SearchTarget& target, const std::string& workingPath);
         ~JvmOption();
 
         mcsm::Result create();

--- a/include/mcsm/data/options/modded/fabric_server_option.h
+++ b/include/mcsm/data/options/modded/fabric_server_option.h
@@ -22,6 +22,7 @@ namespace mcsm {
         bool exists();
 
         mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption);
+        mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update);
 
         mcsm::Result start();
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);

--- a/include/mcsm/data/options/modded/fabric_server_option.h
+++ b/include/mcsm/data/options/modded/fabric_server_option.h
@@ -30,6 +30,8 @@ namespace mcsm {
 
         mcsm::Result update();
 
+        std::string getOptionPath() const;
+
         std::string getServerJarBuild() const;
         mcsm::Result setServerJarBuild(const std::string& build);
 

--- a/include/mcsm/data/options/modded/fabric_server_option.h
+++ b/include/mcsm/data/options/modded/fabric_server_option.h
@@ -25,8 +25,8 @@ namespace mcsm {
         mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update);
 
         mcsm::Result start();
-        mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);
-        mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option, const std::string& path, const std::string& optionPath);
+        mcsm::Result start(mcsm::JvmOption& option);
+        mcsm::Result start(mcsm::JvmOption& option, const std::string& path, const std::string& optionPath);
 
         mcsm::Result update();
 
@@ -48,7 +48,7 @@ namespace mcsm {
         mcsm::Result setServerVersion(const std::string& version);
 
         std::unique_ptr<mcsm::JvmOption> getDefaultOption() const;
-        mcsm::Result setDefaultOption(std::unique_ptr<mcsm::JvmOption> jvmOption);
+        mcsm::Result setDefaultOption(mcsm::JvmOption& jvmOption);
 
         std::string getServerType() const;
 

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2023 dodoman8067
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef __MCSM_MULTI_SERVER_OPTION_H__
+#define __MCSM_MULTI_SERVER_OPTION_H__
+
+#include <mcsm/data/options/server_option.h>
+#include <mcsm/data/options/modded/fabric_server_option.h>
+#include <variant>
+
+namespace mcsm {
+    class MultiServerOption {
+    private:
+        std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> servers;
+        mcsm::Result createProcesses() const;
+    public:
+        MultiServerOption(const std::string& path);
+        ~MultiServerOption();
+        
+        mcsm::Result create() const;
+
+        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>) const;
+        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>) const;
+
+        std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> getServers() const;
+
+        mcsm::Result start() const;
+    };
+}
+
+#endif // __MCSM_MULTI_SERVER_OPTION_H__

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -30,16 +30,20 @@ SOFTWARE.
 namespace mcsm {
     class MultiServerOption {
     private:
+        std::string name;
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> servers;
+        std::unique_ptr<mcsm::Option> option;
+
+        bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:
-        MultiServerOption(const std::string& path);
+        MultiServerOption(const std::string& path, const std::string& name);
         ~MultiServerOption();
         
         mcsm::Result create() const;
 
-        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>) const;
-        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>) const;
+        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const;
+        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const;
 
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> getServers() const;
 

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -30,7 +30,6 @@ SOFTWARE.
 namespace mcsm {
     class MultiServerOption {
     private:
-        std::string name;
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> servers;
         std::unique_ptr<mcsm::Option> option;
 
@@ -40,15 +39,14 @@ namespace mcsm {
         mcsm::Result createProcesses() const;
     public:
         MultiServerOption(const std::string& path);
-        MultiServerOption(const std::string& path, const std::string& name);
         ~MultiServerOption();
         
         bool exists() const;
 
         mcsm::Result create() const;
 
-        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
-        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
+        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>& server);
+        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>& server);
 
         const std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>>& getServers() const;
 

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -35,10 +35,11 @@ namespace mcsm {
         std::unique_ptr<mcsm::Option> option;
 
         mcsm::Result load();
-        mcsm::Result save();
+        mcsm::Result save() const;
         bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:
+        MultiServerOption(const std::string& path);
         MultiServerOption(const std::string& path, const std::string& name);
         ~MultiServerOption();
         

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -34,8 +34,8 @@ namespace mcsm {
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> servers;
         std::unique_ptr<mcsm::Option> option;
 
-        mcsm::Result load() const;
-        mcsm::Result save() const;
+        mcsm::Result load();
+        mcsm::Result save();
         bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -47,7 +47,7 @@ namespace mcsm {
         mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
         mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
 
-        std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> getServers() const;
+        const std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>>& getServers() const;
 
         mcsm::Result start() const;
     };

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -42,6 +42,8 @@ namespace mcsm {
         MultiServerOption(const std::string& path, const std::string& name);
         ~MultiServerOption();
         
+        bool exists() const;
+
         mcsm::Result create() const;
 
         mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -35,7 +35,7 @@ namespace mcsm {
         std::unique_ptr<mcsm::Option> option;
 
         mcsm::Result load();
-        mcsm::Result save() const;
+        mcsm::Result save();
         bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -35,6 +35,7 @@ namespace mcsm {
         std::unique_ptr<mcsm::Option> option;
 
         mcsm::Result load() const;
+        mcsm::Result save() const;
         bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:
@@ -43,8 +44,8 @@ namespace mcsm {
         
         mcsm::Result create() const;
 
-        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const;
-        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const;
+        mcsm::Result addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
+        mcsm::Result removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server);
 
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> getServers() const;
 

--- a/include/mcsm/data/options/multi_server_option.h
+++ b/include/mcsm/data/options/multi_server_option.h
@@ -34,6 +34,7 @@ namespace mcsm {
         std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> servers;
         std::unique_ptr<mcsm::Option> option;
 
+        mcsm::Result load() const;
         bool canBeTaken(const std::string& serverName) const;
         mcsm::Result createProcesses() const;
     public:

--- a/include/mcsm/data/options/server_option.h
+++ b/include/mcsm/data/options/server_option.h
@@ -55,6 +55,8 @@ namespace mcsm {
 
         bool exists();
 
+        std::string getOptionPath() const;
+
         std::string getServerName() const;
         mcsm::Result setServerName(const std::string& name);
 

--- a/include/mcsm/data/options/server_option.h
+++ b/include/mcsm/data/options/server_option.h
@@ -45,6 +45,7 @@ namespace mcsm {
         ~ServerOption();
 
         mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption);
+        mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update);
         
         mcsm::Result start();
         mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);

--- a/include/mcsm/data/options/server_option.h
+++ b/include/mcsm/data/options/server_option.h
@@ -48,8 +48,8 @@ namespace mcsm {
         mcsm::Result create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update);
         
         mcsm::Result start();
-        mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option);
-        mcsm::Result start(std::unique_ptr<mcsm::JvmOption> option, const std::string& path, const std::string& optionPath);
+        mcsm::Result start(mcsm::JvmOption& option);
+        mcsm::Result start(mcsm::JvmOption& option, const std::string& path, const std::string& optionPath);
 
         mcsm::Result update(const std::string& path, const std::string& optionPath);
 
@@ -64,7 +64,7 @@ namespace mcsm {
         mcsm::Result setServerVersion(const std::string& version);
 
         std::unique_ptr<mcsm::JvmOption> getDefaultOption() const;
-        mcsm::Result setDefaultOption(std::unique_ptr<mcsm::JvmOption> jvmOption);
+        mcsm::Result setDefaultOption(mcsm::JvmOption& jvmOption);
 
         std::string getServerType() const;
 

--- a/include/mcsm/server/server_generator.h
+++ b/include/mcsm/server/server_generator.h
@@ -42,32 +42,36 @@ namespace mcsm {
          * @param option server's default JVM launch profile
          * @param version Minecraft version for the server
          * @param type Bukkit-API server implementation (e.g., CRAFTBUKKIT, SPIGOT, PAPER, PURPUR, PUFFERFISH, FOLIA)
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result generateBukkit(const std::string& name, mcsm::JvmOption& option, const std::string& version, const mcsm::BukkitServerType& type);
+        mcsm::Result generateBukkit(const std::string& name, mcsm::JvmOption& option, const std::string& version, const mcsm::BukkitServerType& type, const bool& autoUpdate);
 
         /**
          * Generates a Forge server.
          * @param name server's name
          * @param option server's default JVM launch profile
          * @param version Minecraft version for the server
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result generateForge(const std::string& name, mcsm::JvmOption& option, const std::string& version);
+        mcsm::Result generateForge(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate);
 
         /**
          * Generates a Fabric server.
          * @param name server's name
          * @param option server's default JVM launch profile
          * @param version Minecraft version for the server
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result generateFabric(const std::string& name, mcsm::JvmOption& option, const std::string& version);
+        mcsm::Result generateFabric(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate);
 
         /**
          * Generates a SpongeVanilla server.
          * @param name server's name
          * @param option server's default JVM launch profile
          * @param version Minecraft version for the server
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result generateSponge(const std::string& name, mcsm::JvmOption& option, const std::string& version);
+        mcsm::Result generateSponge(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate);
 
         /**
          * Generates a custom server.
@@ -76,23 +80,25 @@ namespace mcsm {
          * @param filePath jarfile's location (path)
          * @param version Minecraft version for the server
         */
-        mcsm::Result generateCustom(const std::string& name, mcsm::JvmOption& option, const std::string& filePath, const std::string& version);
+        mcsm::Result generateCustom(const std::string& name, mcsm::JvmOption& option, const std::string& filePath, const std::string& version, const bool& autoUpdate);
 
         /**
          * Generates a Vanilla server.
          * @param name server's name
          * @param option server's default JVM launch profile
          * @param version Minecraft version for the server
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result generateVanilla(const std::string& name, mcsm::JvmOption& option, const std::string& version);
+        mcsm::Result generateVanilla(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate);
 
         /**
          * Configures a server.
          * @param serverOption pointer of mcsm::ServerOption
          * @param name server's name
          * @param option server's default JVM launch profile
+         * @param autoUpdate sets if the server should automatically update upon starting
         */
-        mcsm::Result configure(std::unique_ptr<mcsm::ServerOption> serverOption, const std::string& name, mcsm::JvmOption& option);
+        mcsm::Result configure(std::unique_ptr<mcsm::ServerOption> serverOption, const std::string& name, mcsm::JvmOption& option, const bool& autoUpdate);
 
         /**
          * Returns a pointer of server instance based on `server`.

--- a/include/mcsm/server/type/custom_server.h
+++ b/include/mcsm/server/type/custom_server.h
@@ -41,7 +41,7 @@ namespace mcsm {
 
         std::string getFileLocation(const std::string& optionPath) const;
         mcsm::Result setFileLocation(const std::string& optionPath, const std::string& location);
-        mcsm::Result getFileFromLocation(const std::string& optionPath);
+        mcsm::Result setupServerJarFile(const std::string& optionPath);
 
         std::string getSupportedVersions() const override;
 

--- a/include/mcsm/server/type/custom_server.h
+++ b/include/mcsm/server/type/custom_server.h
@@ -32,17 +32,16 @@ namespace mcsm {
     private:
         bool isFile(const std::string& location) const;
         bool isURL(const std::string& location) const;
-        std::string directory;
     public:
-        CustomServer(const std::string& dir);
+        CustomServer();
         ~CustomServer();
 
         mcsm::ServerType getType() const override;
         std::string getTypeAsString() const override;
 
-        std::string getFileLocation() const;
-        mcsm::Result setFileLocation(const std::string& location);
-        mcsm::Result getFileFromLocation();
+        std::string getFileLocation(const std::string& optionPath) const;
+        mcsm::Result setFileLocation(const std::string& optionPath, const std::string& location);
+        mcsm::Result getFileFromLocation(const std::string& optionPath);
 
         std::string getSupportedVersions() const override;
 

--- a/include/mcsm/server/type/custom_server.h
+++ b/include/mcsm/server/type/custom_server.h
@@ -32,8 +32,9 @@ namespace mcsm {
     private:
         bool isFile(const std::string& location) const;
         bool isURL(const std::string& location) const;
+        std::string directory;
     public:
-        CustomServer();
+        CustomServer(const std::string& dir);
         ~CustomServer();
 
         mcsm::ServerType getType() const override;

--- a/include/mcsm/util/cli/result.h
+++ b/include/mcsm/util/cli/result.h
@@ -24,6 +24,7 @@ SOFTWARE.
 #define __MCSM_RESULT_H__
 
 #include <vector>
+#include <mutex>
 #include <mcsm/util/cli/logging.h>
 
 namespace mcsm {

--- a/include/mcsm/util/cli/result.h
+++ b/include/mcsm/util/cli/result.h
@@ -143,9 +143,23 @@ namespace mcsm {
             };
         }
 
+        inline std::vector<std::string> serverAlreadyConfigured(const std::string& dir){
+            return {
+                "Server already configured in " + dir + ".",
+                "Please try again in other directories."
+            };
+        }
+
         inline std::vector<std::string> serverNotConfigured(){
             return {
                 "Server isn't configured in this directory",
+                "Run \"mcsm init\" to configure a server."
+            };
+        }
+
+        inline std::vector<std::string> serverNotConfigured(const std::string& dir){
+            return {
+                "Server not configured in " + dir + ".",
                 "Run \"mcsm init\" to configure a server."
             };
         }

--- a/include/mcsm/util/os/os_detection.h
+++ b/include/mcsm/util/os/os_detection.h
@@ -27,7 +27,7 @@ namespace mcsm {
     /**
      * Enum of supported operating systems.
     */
-    enum OS {
+    enum class OS {
         /**
          * Represents Microsoft Windows operating system.
         */

--- a/include/mcsm/util/string_utils.h
+++ b/include/mcsm/util/string_utils.h
@@ -57,6 +57,8 @@ namespace mcsm {
      * @param replacement string to replace `value` with
      */
     void replaceAll(std::string& str, const std::string& value, const std::string& replacement);
+
+    std::string safeString(const std::string& str);
 }
 
 #endif

--- a/src/command/server/generate_server_command.cpp
+++ b/src/command/server/generate_server_command.cpp
@@ -213,6 +213,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
     std::string version = getServerVersion(args);
     std::string name = getServerName(args);
     std::string type = getServerType(args);
+    bool shouldSkipUpdate = !shouldSkipAutoUpdate(args);
 
     if(option == nullptr){
         mcsm::warning("JVM launch profile " + getProfileName(args) + " not found.");
@@ -221,7 +222,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
     }
 
     if(type == "bukkit" || type == "craftbukkit"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::CRAFTBUKKIT, true);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::CRAFTBUKKIT, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -229,7 +230,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "spigot"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::SPIGOT, true);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::SPIGOT, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -237,7 +238,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "paper" || type == "paperspigot"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PAPER, true);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PAPER, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -245,7 +246,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "purpur"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PURPUR, true);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PURPUR, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -253,7 +254,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "fabric"){
-        mcsm::Result res = mcsm::server::generateFabric(name, *option, version, true);
+        mcsm::Result res = mcsm::server::generateFabric(name, *option, version, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -261,7 +262,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "vanilla"){
-        mcsm::Result res = mcsm::server::generateVanilla(name, *option, version, true);
+        mcsm::Result res = mcsm::server::generateVanilla(name, *option, version, shouldSkipUpdate);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);

--- a/src/command/server/generate_server_command.cpp
+++ b/src/command/server/generate_server_command.cpp
@@ -201,7 +201,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
     }
 
     if(type == "bukkit" || type == "craftbukkit"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::CRAFTBUKKIT);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::CRAFTBUKKIT, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -209,7 +209,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "spigot"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::SPIGOT);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::SPIGOT, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -217,7 +217,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "paper" || type == "paperspigot"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PAPER);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PAPER, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -225,7 +225,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "purpur"){
-        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PURPUR);
+        mcsm::Result res = mcsm::server::generateBukkit(name, *option, version, mcsm::BukkitServerType::PURPUR, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -233,7 +233,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "fabric"){
-        mcsm::Result res = mcsm::server::generateFabric(name, *option, version);
+        mcsm::Result res = mcsm::server::generateFabric(name, *option, version, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
@@ -241,7 +241,7 @@ void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& a
         return;
     }
     if(type == "vanilla"){
-        mcsm::Result res = mcsm::server::generateVanilla(name, *option, version);
+        mcsm::Result res = mcsm::server::generateVanilla(name, *option, version, true);
         if(!res.isSuccess()){
             res.printMessage();
             if(res.getResult() != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);

--- a/src/command/server/generate_server_command.cpp
+++ b/src/command/server/generate_server_command.cpp
@@ -58,7 +58,15 @@ const std::vector<std::string> availableOptions = {
     "--ver",
     "-ver",
     "--v",
-    "-v"
+    "-v",
+    "--no-auto-update",
+    "-no-auto-update",
+    "--no-auto-updates",
+    "-no-auto-updates",
+    "--skip-auto-update",
+    "-skip-auto-update",
+    "--skip-auto-updates",
+    "-skip-auto-updates"
 };
 
 mcsm::GenerateServerCommand::GenerateServerCommand(const std::string& name, const std::string& description) : Command(name, description) {}
@@ -162,7 +170,7 @@ std::unique_ptr<mcsm::JvmOption> mcsm::GenerateServerCommand::searchOption(const
     return nullptr;
 }
 
-mcsm::SearchTarget mcsm::GenerateServerCommand::getSearchTarget(const std::vector<std::string>& args){
+mcsm::SearchTarget mcsm::GenerateServerCommand::getSearchTarget(const std::vector<std::string>& args) const {
     if(args.empty()) return mcsm::SearchTarget::ALL;
     for(const std::string& arg : args) {
         if(arg == "--global" || arg == "-global" || arg == "--g" || arg == "-g") return mcsm::SearchTarget::GLOBAL;
@@ -185,6 +193,18 @@ std::string mcsm::GenerateServerCommand::getServerType(const std::vector<std::st
     }
     mcsm::warning("Server type not provided; To continue, specify a type with --servertype option.");
     std::exit(1);
+}
+
+bool mcsm::GenerateServerCommand::shouldSkipAutoUpdate(const std::vector<std::string>& args) const {
+    for(size_t i = 0; i < args.size(); ++i){
+        const std::string& arg = args[i];
+        if(std::find(availableOptions.begin(), availableOptions.end(), arg) != availableOptions.end()){
+            if(!(arg == "-no-auto-update" || arg == "-no-auto-updates" || arg == "--no-auto-update" || arg == "--no-auto-updates"
+            || arg == "-skip-auto-update" || arg == "-skip-auto-updates" || arg == "--skip-auto-update" || arg == "--skip-auto-updates")) continue;
+            return true;
+        }
+    }
+    return false;
 }
 
 void mcsm::GenerateServerCommand::detectServer(const std::vector<std::string>& args){

--- a/src/command/server/jvm/jvm_option_edit_command.cpp
+++ b/src/command/server/jvm/jvm_option_edit_command.cpp
@@ -71,6 +71,7 @@ mcsm::SearchTarget mcsm::JvmOptionEditCommand::getSearchTarget(const std::vector
 
 std::string mcsm::JvmOptionEditCommand::getJvmPath(const std::vector<std::string>& args) const {
     std::string jvmPath;
+    bool valid = false;
     for(size_t i = 0; i < args.size(); ++i){
         const std::string& arg = args[i];
         if(std::find(availableOptions.begin(), availableOptions.end(), arg) != availableOptions.end()){
@@ -83,13 +84,16 @@ std::string mcsm::JvmOptionEditCommand::getJvmPath(const std::vector<std::string
                 if(!mcsm::endsWith(jvmPath, "\"") && !mcsm::endsWith(jvmPath, "\'")){
                     jvmPath += "\"";
                 }
-                if (!mcsm::isValidJava(jvmPath)) continue;
-                mcsm::success("Detected java from specified path : " + jvmPath);
+                if(!mcsm::isValidJava(jvmPath)){
+                    valid = false;
+                    continue;
+                }
+                valid = true;
                 return jvmPath;
             }
         }
     }
-    mcsm::info("JVM not detected or not a valid JVM. Ignoring..");
+    if(!mcsm::isWhitespaceOrEmpty(jvmPath) && !valid) mcsm::info("Not a valid JVM path. Ignoring..");
     return "";
 }
 

--- a/src/command/server/start_server_command.cpp
+++ b/src/command/server/start_server_command.cpp
@@ -60,10 +60,10 @@ void mcsm::StartServerCommand::execute(const std::vector<std::string>& args){
             mcsm::printResultMessage();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
         }
-        mcsm::Result res = fsOpt.start(std::move(jvmOpt));
+        mcsm::Result res = fsOpt.start(*jvmOpt);
         res.printMessage();
     }else{
-        mcsm::Result res = sOpt.start(std::move(jvmOpt));
+        mcsm::Result res = sOpt.start(*jvmOpt);
         res.printMessage();
     }
 }

--- a/src/data/global_option.cpp
+++ b/src/data/global_option.cpp
@@ -27,6 +27,8 @@ mcsm::GlobalOption::GlobalOption(const std::string& path, const std::string& nam
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
 
     std::string name1 = name;
+    mcsm::replaceAll(name1, "..", "__");
+    mcsm::replaceAll(name1, "/", "_");
     if(!mcsm::endsWith(name1, ".json")){
         name1 = name1.append(".json");
     }

--- a/src/data/option.cpp
+++ b/src/data/option.cpp
@@ -26,6 +26,8 @@ mcsm::Option::Option(const std::string& path, const std::string& name){
     this->path = path;
 
     std::string name1 = name;
+    mcsm::replaceAll(name1, "..", "__");
+    mcsm::replaceAll(name1, "/", "_");
     if(!mcsm::endsWith(name1, ".json")){
         name1 = name1.append(".json");
     }

--- a/src/data/options/jvm_option.cpp
+++ b/src/data/options/jvm_option.cpp
@@ -26,6 +26,10 @@ mcsm::JvmOption::JvmOption(const std::string& name) : JvmOption(name, mcsm::Sear
 
 mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& target){
     this->name = name;
+    std::string name1 = name;
+    mcsm::replaceAll(name1, ".", "_");
+    mcsm::replaceAll(name1, "/", "_");
+    this->name = name1;
     switch (target){
         case mcsm::SearchTarget::ALL: {
             mcsm::GlobalOption globalOption("/jvm/profiles", name);
@@ -125,7 +129,6 @@ mcsm::Result mcsm::JvmOption::create(const std::string& jvmPath, const std::vect
         filePath = globalOption.getPath();
         optionName = globalOption.getName();
     }
-
     bool fileExists = mcsm::fileExists(filePath + "/" + optionName);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
@@ -133,12 +136,10 @@ mcsm::Result mcsm::JvmOption::create(const std::string& jvmPath, const std::vect
         return res;
     }
     if(fileExists){
-        mcsm::removeFile(filePath + "/" + optionName);
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
-            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
-            mcsm::Result res(resp.first, resp.second);
-            return res;
-        }
+        mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+            "JVM lanuch profile " + this->name + " already exists."
+        }});
+        return res;
     }
 
     mcsm::Result invaildPath({mcsm::ResultType::MCSM_SUCCESS, {"Invaild jvm path.", "High chance to be a software issue, please report this to GitHub (https://github.com/dodoman8067/mcsm)."}});

--- a/src/data/options/jvm_option.cpp
+++ b/src/data/options/jvm_option.cpp
@@ -38,9 +38,8 @@ mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& ta
             mcsm::GlobalOption globalOption("/jvm/profiles", name);
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
             if(globalOption.exists()){
-                auto optPtr = new mcsm::GlobalOption("/jvm/profiles", name);
                 if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
-                this->option.reset(optPtr);
+                this->option.reset(new mcsm::GlobalOption(globalOption));
             }else{
                 this->option.reset(new mcsm::Option(mcsm::getCurrentPath() + "/.mcsm/jvm/profiles", name));
             }
@@ -50,16 +49,15 @@ mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& ta
             mcsm::GlobalOption globalOption("/jvm/profiles", name);
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
             if(globalOption.exists()){
-                auto optPtr = new mcsm::GlobalOption("/jvm/profiles", name);
                 if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
-                this->option.reset(optPtr);
+                this->option.reset(new mcsm::GlobalOption(globalOption));
             }
             break;
         }
         case mcsm::SearchTarget::CURRENT: {
-            mcsm::Option option(workingPath + "/.mcsm/jvm/profiles", name);
-            if(option.exists()){
-                this->option.reset(new mcsm::Option(workingPath + "/.mcsm/jvm/profiles", name));
+            mcsm::Option option1(workingPath + "/.mcsm/jvm/profiles", name);
+            if(option1.exists()){
+                this->option.reset(new mcsm::Option(option1));
             }
             break;
         }

--- a/src/data/options/jvm_option.cpp
+++ b/src/data/options/jvm_option.cpp
@@ -22,14 +22,17 @@ SOFTWARE.
 
 #include <mcsm/data/options/jvm_option.h>
 
-mcsm::JvmOption::JvmOption(const std::string& name) : JvmOption(name, mcsm::SearchTarget::ALL) {}
+mcsm::JvmOption::JvmOption(const std::string& name) : JvmOption(name, mcsm::SearchTarget::ALL, mcsm::getCurrentPath()) {}
 
-mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& target){
+mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& target) : JvmOption(name, target, mcsm::getCurrentPath()) {}
+
+mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& target, const std::string& workingPath){
     this->name = name;
     std::string name1 = name;
     mcsm::replaceAll(name1, ".", "_");
     mcsm::replaceAll(name1, "/", "_");
     this->name = name1;
+    this->workingDir = workingPath;
     switch (target){
         case mcsm::SearchTarget::ALL: {
             mcsm::GlobalOption globalOption("/jvm/profiles", name);
@@ -54,9 +57,9 @@ mcsm::JvmOption::JvmOption(const std::string& name, const mcsm::SearchTarget& ta
             break;
         }
         case mcsm::SearchTarget::CURRENT: {
-            mcsm::Option option(mcsm::getCurrentPath() + "/.mcsm/jvm/profiles", name);
+            mcsm::Option option(workingPath + "/.mcsm/jvm/profiles", name);
             if(option.exists()){
-                this->option.reset(new mcsm::Option(mcsm::getCurrentPath() + "/.mcsm/jvm/profiles", name));
+                this->option.reset(new mcsm::Option(workingPath + "/.mcsm/jvm/profiles", name));
             }
             break;
         }
@@ -87,6 +90,8 @@ mcsm::Result mcsm::JvmOption::create(){
     return create(jvm, jvmArgs, serverArgs, mcsm::SearchTarget::GLOBAL);
 }
 
+// Reason why the program takes SearchTarget as a parameter (was taken in the constructor) is because there's chance that constructor's specified SearchTarget might be ALL.
+
 mcsm::Result mcsm::JvmOption::create(const std::string& jvmPath, const mcsm::SearchTarget& target){
     std::vector<std::string> jvmArgs = {
         "-Xms2G",
@@ -111,7 +116,7 @@ mcsm::Result mcsm::JvmOption::create(const std::string& jvmPath, const std::vect
     std::string optionName;
 
     if(target == mcsm::SearchTarget::CURRENT){
-        mcsm::Option option(mcsm::getCurrentPath() + "/.mcsm/jvm/profiles", this->name);
+        mcsm::Option option(this->workingDir + "/.mcsm/jvm/profiles", this->name);
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);
@@ -145,7 +150,7 @@ mcsm::Result mcsm::JvmOption::create(const std::string& jvmPath, const std::vect
     mcsm::Result invaildPath({mcsm::ResultType::MCSM_SUCCESS, {"Invaild jvm path.", "High chance to be a software issue, please report this to GitHub (https://github.com/dodoman8067/mcsm)."}});
     if(target == mcsm::SearchTarget::ALL) return invaildPath;
     if(target == mcsm::SearchTarget::CURRENT){
-        mcsm::Option* cOpt = new mcsm::Option(mcsm::getCurrentPath() + "/.mcsm/jvm/profiles", optionName);
+        mcsm::Option* cOpt = new mcsm::Option(this->workingDir + "/.mcsm/jvm/profiles", optionName);
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);

--- a/src/data/options/modded/fabric_server_option.cpp
+++ b/src/data/options/modded/fabric_server_option.cpp
@@ -412,6 +412,10 @@ bool mcsm::FabricServerOption::exists(){
     return rt;
 }
 
+std::string mcsm::FabricServerOption::getOptionPath() const {
+    return this->path;
+}
+
 std::unique_ptr<mcsm::JvmOption> mcsm::FabricServerOption::getDefaultOption() const{
     mcsm::Option option(this->path, "server");
     bool optExists = option.exists();

--- a/src/data/options/modded/fabric_server_option.cpp
+++ b/src/data/options/modded/fabric_server_option.cpp
@@ -23,7 +23,7 @@ mcsm::FabricServerOption::FabricServerOption(const std::string& version, const s
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
 
     if(!exists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(path)});
         return;
     }
 
@@ -82,7 +82,7 @@ mcsm::FabricServerOption::FabricServerOption(const std::string& path){
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
 
     if(!exists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(path)});
         return;
     }
 
@@ -184,7 +184,7 @@ mcsm::Result mcsm::FabricServerOption::create(const std::string& name, mcsm::Jvm
     }
 
     if(optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured(this->path)});
         return res;
     }
 
@@ -281,7 +281,7 @@ mcsm::Result mcsm::FabricServerOption::start(mcsm::JvmOption& option, const std:
     }
 
     if(!fileExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(optionPath)});
         return res;
     }
 
@@ -355,7 +355,7 @@ std::string mcsm::FabricServerOption::getLoaderVersion() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -385,7 +385,7 @@ std::string mcsm::FabricServerOption::getInstallerVersion() const{
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -426,7 +426,7 @@ std::unique_ptr<mcsm::JvmOption> mcsm::FabricServerOption::getDefaultOption() co
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return nullptr;
     }
     nlohmann::json profileObj = option.getValue("default_launch_profile");
@@ -518,7 +518,7 @@ std::string mcsm::FabricServerOption::getServerName() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -548,7 +548,7 @@ std::string mcsm::FabricServerOption::getServerVersion() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -578,7 +578,7 @@ std::string mcsm::FabricServerOption::getServerType() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -603,7 +603,7 @@ std::string mcsm::FabricServerOption::getServerJarFile() const{
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -633,7 +633,7 @@ bool mcsm::FabricServerOption::doesAutoUpdate() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 

--- a/src/data/options/modded/fabric_server_option.cpp
+++ b/src/data/options/modded/fabric_server_option.cpp
@@ -170,6 +170,10 @@ mcsm::FabricServerOption::~FabricServerOption(){
 }
 
 mcsm::Result mcsm::FabricServerOption::create(const std::string& name, mcsm::JvmOption& defaultOption){
+    return create(name, defaultOption, true);
+}
+
+mcsm::Result mcsm::FabricServerOption::create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update){
     mcsm::Option option(this->path, "server");
     
     bool optExists = option.exists();
@@ -228,7 +232,7 @@ mcsm::Result mcsm::FabricServerOption::create(const std::string& name, mcsm::Jvm
     mcsm::Result res6 = option.setValue("server_build", "latest");
     if(!res6.isSuccess()) return res6;
 
-    mcsm::Result res12 = option.setValue("auto_update", true);
+    mcsm::Result res12 = option.setValue("auto_update", update);
     if(!res12.isSuccess()) return res12;
     
     mcsm::Result res7 = option.setValue("type", this->server->getTypeAsString());

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -36,7 +36,7 @@ mcsm::MultiServerOption::MultiServerOption(const std::string& path, const std::s
     bool isPath = std::filesystem::is_directory(path, ec);
     if(ec){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
-            "Checking if path " + path + "is a path operation failed : " + ec.message(), 
+            "Checking if " + path + " is a path operation failed : " + ec.message(), 
             "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
         }});
         return;
@@ -49,6 +49,18 @@ mcsm::MultiServerOption::MultiServerOption(const std::string& path, const std::s
         return;
     }
     this->option = std::make_unique<mcsm::Option>(path, "multi_server_" + this->name);
+
+    bool exists = this->option->exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return;
+    }
+
+    if(exists){
+        mcsm::Result res = load();
+        if(!res.isSuccess()) return;
+    }
 }
 
 mcsm::Result mcsm::MultiServerOption::create() const {
@@ -162,6 +174,16 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
     }
     
     this->servers.push_back(std::move(server));
+
+    return save();
+}
+
+mcsm::Result mcsm::MultiServerOption::removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server){
+
+}
+
+std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> mcsm::MultiServerOption::getServers() const {
+    return this->servers;
 }
 
 mcsm::MultiServerOption::~MultiServerOption(){

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -1,0 +1,124 @@
+/*
+MIT License
+
+Copyright (c) 2023 dodoman8067
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <mcsm/data/options/multi_server_option.h>
+
+mcsm::MultiServerOption::MultiServerOption(const std::string& path, const std::string& name){
+    this->name = mcsm::safeString(name);
+    mcsm::fileExists(path);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return;
+    }
+    std::error_code ec;
+    bool isPath = std::filesystem::is_directory(path, ec);
+    if(ec){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Checking if path " + path + "is a path operation failed : " + ec.message(), 
+            "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
+        }});
+        return;
+    }
+    if(!isPath){
+        mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+            "Non-directory path was passed : " + path, 
+            "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
+        }});
+        return;
+    }
+    this->option = std::make_unique<mcsm::Option>(path, "multi_server_" + this->name);
+}
+
+mcsm::Result mcsm::MultiServerOption::create() const {
+    bool exists = this->option->exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    if(exists){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
+        return res;
+    }
+
+    mcsm::Result res1 = this->option->setValue("name", this->name);
+    if(!res1.isSuccess()) return res1;
+    mcsm::Result res2 = this->option->setValue("servers", nlohmann::json::array());
+    if(!res2.isSuccess()) return res2;
+
+    mcsm::Result res3({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return res3;
+}
+
+mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const {
+    std::string name, path;
+    if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*server)){
+        bool exists = sPtr->exists();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+
+        name = sPtr->getServerName();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+
+        path = sPtr->getOptionPath();
+
+    }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*server)){
+        bool exists = fsPtr->exists();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+
+        name = fsPtr->getServerName();
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+
+        path = fsPtr->getOptionPath();
+    }else{
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "std::variant<mcsm::ServerOption, mcsm::FabricServerOption> test didn't pass.",
+            "Open an issue in GitHub (https://github.com/dodoman8067/mcsm) and tell how you got this message."
+        }});
+        return res;
+    }
+
+    //TODO : Check if the server option's name matches with other linked servers and add the server option instance 
+}
+
+mcsm::MultiServerOption::~MultiServerOption(){
+
+}

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -63,6 +63,12 @@ mcsm::MultiServerOption::MultiServerOption(const std::string& path, const std::s
     }
 }
 
+bool mcsm::MultiServerOption::exists() const {
+    bool rt = this->option->exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+    return rt;
+}
+
 mcsm::Result mcsm::MultiServerOption::create() const {
     bool exists = this->option->exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -293,7 +293,7 @@ mcsm::Result mcsm::MultiServerOption::load(){
 }
 
 mcsm::Result mcsm::MultiServerOption::save(){
-    std::string sName;
+    std::string sName, sPath;
 
     bool exists = this->option->exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -353,6 +353,24 @@ mcsm::Result mcsm::MultiServerOption::save(){
                 return res;
             }
 
+            sPath = sPtr->getOptionPath();
+
+            nlohmann::json sArr = this->option->getValue("servers");
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+            if(sArr == nullptr){
+                mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonNotFound("\"servers\"", this->option->getName())});
+                return res;
+            }
+            if(!sArr.is_array()){
+                mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonWrongType("\"servers\"", "array of json object")});
+                return res;
+            }
+
         }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*v)){
             bool exists = fsPtr->exists();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -373,6 +391,24 @@ mcsm::Result mcsm::MultiServerOption::save(){
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
                 std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
                 mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+            sPath = sPtr->getOptionPath();
+
+            nlohmann::json sArr = this->option->getValue("servers");
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+            if(sArr == nullptr){
+                mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonNotFound("\"servers\"", this->option->getName())});
+                return res;
+            }
+            if(!sArr.is_array()){
+                mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonWrongType("\"servers\"", "array of json object")});
                 return res;
             }
         }else{

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -292,8 +292,40 @@ mcsm::Result mcsm::MultiServerOption::load(){
     return successfulRes;
 }
 
-mcsm::Result mcsm::MultiServerOption::save() const {
+mcsm::Result mcsm::MultiServerOption::save(){
+    bool exists = this->option->exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
 
+    if(!exists){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        return res;
+    }
+
+    nlohmann::json optName = this->option->getValue("name");
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    if(optName == nullptr){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonNotFound("\"name\"", this->option->getName())});
+        return res;
+    }
+    if(!optName.is_string()){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonWrongType("\"name\"", "string")});
+        return res;
+    }
+
+    std::string finalName = mcsm::safeString(std::string(optName));
+
+    if(finalName != this->name){
+        this->name = finalName;
+    }
 }
 
 bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -153,7 +153,7 @@ mcsm::Result mcsm::MultiServerOption::load(){
 
         if(path == this->option->getPath()){
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                "Multi server configuration file and its linked server configuration file cannot exist in the same path." 
+                "Multi server configuration file and its linked server configuration file cannot exist in the same path.",
                 "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
             }});
             return res;
@@ -170,7 +170,7 @@ mcsm::Result mcsm::MultiServerOption::load(){
         
         if(!optExists){
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                "Cannot link a server configuration file that doesn't exist." 
+                "Cannot link a server configuration file that doesn't exist.",
                 "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
             }});
             return res;
@@ -201,6 +201,9 @@ mcsm::Result mcsm::MultiServerOption::load(){
             this->servers.push_back(std::make_unique<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>(std::move(*base)));
         }
     }
+
+    mcsm::Result successfulRes({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return successfulRes;
 }
 
 bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
@@ -209,6 +212,13 @@ bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
         if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*v)){
             bool exists = sPtr->exists();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+            if(!exists){
+                mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                    "Program tried to check a server configuration file that doesn't exist.",
+                    "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+                }});
+                return false;
+            }
 
             name = sPtr->getServerName();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
@@ -217,6 +227,13 @@ bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
         }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*v)){
             bool exists = fsPtr->exists();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+            if(!exists){
+                mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                    "Cannot link a server configuration file that doesn't exist.",
+                    "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+                }});
+                return false;
+            }
 
             name = fsPtr->getServerName();
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
@@ -242,6 +259,13 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
             mcsm::Result res(resp.first, resp.second);
             return res;
         }
+        if(!exists){
+            mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                "Cannot link a server configuration file that doesn't exist.",
+                "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+            }});
+            return res;
+        }
 
         name = sPtr->getServerName();
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -257,6 +281,13 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
             std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
             mcsm::Result res(resp.first, resp.second);
+            return res;
+        }
+        if(!exists){
+            mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                "Cannot link a server configuration file that doesn't exist.",
+                "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+            }});
             return res;
         }
 
@@ -293,14 +324,15 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
     
     this->servers.push_back(std::move(server));
 
-    return save();
+    mcsm::Result successfulRes({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
+    return successfulRes;
 }
 
-mcsm::Result mcsm::MultiServerOption::removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server){
+mcsm::Result mcsm::MultiServerOption::removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> /* server */){
 
 }
 
-std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>> mcsm::MultiServerOption::getServers() const {
+const std::vector<std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>>& mcsm::MultiServerOption::getServers() const {
     return this->servers;
 }
 

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -152,7 +152,7 @@ mcsm::Result mcsm::MultiServerOption::load(){
         return res;
     }
 
-    this->name = std::string(optName);
+    this->name = mcsm::safeString(std::string(optName));
 
     nlohmann::json serverArray = this->option->getValue("servers");
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -259,14 +259,14 @@ mcsm::Result mcsm::MultiServerOption::load(){
                 return res;
             }
 
-            bool taked = canBeTaken(name);
+            bool canTake = canBeTaken(name);
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
                 std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
                 mcsm::Result res(resp.first, resp.second);
                 return res;
             }
 
-            if(!taked) this->servers.push_back(std::make_unique<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>(std::move(*fabric)));
+            if(canTake) this->servers.push_back(std::make_unique<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>(std::move(*fabric)));
         }else{
             std::unique_ptr<mcsm::ServerOption> base = std::make_unique<mcsm::ServerOption>(path);
 
@@ -277,14 +277,14 @@ mcsm::Result mcsm::MultiServerOption::load(){
                 return res;
             }
 
-            bool taked = canBeTaken(name);
+            bool canTake = canBeTaken(name);
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
                 std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
                 mcsm::Result res(resp.first, resp.second);
                 return res;
             }
 
-            if(!taked) this->servers.push_back(std::make_unique<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>(std::move(*base)));
+            if(canTake) this->servers.push_back(std::make_unique<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>>(std::move(*base)));
         }
     }
 

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -26,12 +26,18 @@ SOFTWARE.
 
 mcsm::MultiServerOption::MultiServerOption(const std::string& path, const std::string& name){
     this->name = mcsm::safeString(name);
-    mcsm::fileExists(path);
+    bool pathExists = mcsm::fileExists(path);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
         mcsm::Result res(resp.first, resp.second);
         return;
     }
+    
+    if(!pathExists){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        return;
+    }
+
     std::error_code ec;
     bool isPath = std::filesystem::is_directory(path, ec);
     if(ec){

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -73,6 +73,36 @@ mcsm::Result mcsm::MultiServerOption::create() const {
     return res3;
 }
 
+bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
+    std::string name;
+    for(auto& v : this->servers){
+        if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*v)){
+            bool exists = sPtr->exists();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+
+            name = sPtr->getServerName();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+
+            if(name == serverName) return false;
+        }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*v)){
+            bool exists = fsPtr->exists();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+
+            name = fsPtr->getServerName();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
+
+            if(name == serverName) return false;
+        }else{
+            mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+                "std::variant<mcsm::ServerOption, mcsm::FabricServerOption> test didn't pass.",
+                "Open an issue in GitHub (https://github.com/dodoman8067/mcsm) and tell us how did you got this message."
+            }});
+            return false;
+        }
+    }
+    return true;
+}
+
 mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server) const {
     std::string name, path;
     if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*server)){
@@ -111,7 +141,7 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
     }else{
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
             "std::variant<mcsm::ServerOption, mcsm::FabricServerOption> test didn't pass.",
-            "Open an issue in GitHub (https://github.com/dodoman8067/mcsm) and tell how you got this message."
+            "Open an issue in GitHub (https://github.com/dodoman8067/mcsm) and tell us how did you get this message."
         }});
         return res;
     }

--- a/src/data/options/multi_server_option.cpp
+++ b/src/data/options/multi_server_option.cpp
@@ -226,7 +226,7 @@ mcsm::Result mcsm::MultiServerOption::load(){
         
         if(!optExists){
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                "Cannot link a server configuration file that doesn't exist.",
+                "Cannot load a server configuration file that doesn't exist.",
                 "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
             }});
             return res;
@@ -293,6 +293,8 @@ mcsm::Result mcsm::MultiServerOption::load(){
 }
 
 mcsm::Result mcsm::MultiServerOption::save(){
+    std::string sName;
+
     bool exists = this->option->exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
@@ -326,6 +328,61 @@ mcsm::Result mcsm::MultiServerOption::save(){
     if(finalName != this->name){
         this->name = finalName;
     }
+
+    for(auto& v : this->servers){
+        if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*v)){
+            bool exists = sPtr->exists();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+            if(!exists){
+                mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                    "Cannot load a server configuration file that doesn't exist.",
+                    "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+                }});
+                return res;
+            }
+
+            sName = sPtr->getServerName();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+        }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*v)){
+            bool exists = fsPtr->exists();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+
+            if(!exists){
+                mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
+                    "Cannot load a server configuration file that doesn't exist.",
+                    "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+                }});
+                return res;
+            }
+
+            sName = fsPtr->getServerName();
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+        }else{
+            mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+                "std::variant<mcsm::ServerOption, mcsm::FabricServerOption> test didn't pass.",
+                "Open an issue in GitHub (https://github.com/dodoman8067/mcsm) and tell us how did you got this message."
+            }});
+            return res;
+        }
+    }
 }
 
 bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
@@ -336,7 +393,7 @@ bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
             if(!exists){
                 mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                    "Program tried to check a server configuration file that doesn't exist.",
+                    "Cannot load a server configuration file that doesn't exist.",
                     "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
                 }});
                 return false;
@@ -351,7 +408,7 @@ bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
             if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return false;
             if(!exists){
                 mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                    "Cannot link a server configuration file that doesn't exist.",
+                    "Cannot load a server configuration file that doesn't exist.",
                     "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
                 }});
                 return false;
@@ -373,7 +430,7 @@ bool mcsm::MultiServerOption::canBeTaken(const std::string& serverName) const {
 }
 
 mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> server){
-    std::string name, path;
+    std::string name;
     if(mcsm::ServerOption* sPtr = std::get_if<mcsm::ServerOption>(&*server)){
         bool exists = sPtr->exists();
         if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -383,7 +440,7 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
         }
         if(!exists){
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                "Cannot link a server configuration file that doesn't exist.",
+                "Cannot load a server configuration file that doesn't exist.",
                 "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
             }});
             return res;
@@ -396,7 +453,7 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
             return res;
         }
 
-        path = sPtr->getOptionPath();
+        //path = sPtr->getOptionPath();
         
     }else if (mcsm::FabricServerOption* fsPtr = std::get_if<mcsm::FabricServerOption>(&*server)){
         bool exists = fsPtr->exists();
@@ -407,7 +464,7 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
         }
         if(!exists){
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-                "Cannot link a server configuration file that doesn't exist.",
+                "Cannot load a server configuration file that doesn't exist.",
                 "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
             }});
             return res;
@@ -420,7 +477,7 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
             return res;
         }
 
-        path = fsPtr->getOptionPath();
+        //path = fsPtr->getOptionPath();
     }else{
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
             "std::variant<mcsm::ServerOption, mcsm::FabricServerOption> test didn't pass.",
@@ -439,15 +496,14 @@ mcsm::Result mcsm::MultiServerOption::addServer(std::unique_ptr<std::variant<mcs
 
     if(!validName){
         mcsm::Result res({mcsm::ResultType::MCSM_WARN, {
-            "Current server name \"" + name + "\" is already taken in this multiserver configuration."
+            "Current server name \"" + name + "\" is already taken on this multiserver configuration."
         }});
         return res;
     }
     
     this->servers.push_back(std::move(server));
 
-    mcsm::Result successfulRes({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
-    return successfulRes;
+    return save();
 }
 
 mcsm::Result mcsm::MultiServerOption::removeServer(std::unique_ptr<std::variant<mcsm::ServerOption, mcsm::FabricServerOption>> /* server */){

--- a/src/data/options/server_data_option.cpp
+++ b/src/data/options/server_data_option.cpp
@@ -50,7 +50,7 @@ mcsm::Result mcsm::ServerDataOption::create(const std::string& lastTimeLaunched)
         return res;
     }
     if(optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured(this->option->getPath())});
         return res;
     }
     mcsm::Result res1 = this->option->setValue("last_time_launched", lastTimeLaunched);

--- a/src/data/options/server_option.cpp
+++ b/src/data/options/server_option.cpp
@@ -163,6 +163,10 @@ mcsm::ServerOption::~ServerOption(){
 }
 
 mcsm::Result mcsm::ServerOption::create(const std::string& name, mcsm::JvmOption& defaultOption){
+    return create(name, defaultOption, true);
+}
+
+mcsm::Result mcsm::ServerOption::create(const std::string& name, mcsm::JvmOption& defaultOption, const bool& update){
     mcsm::Option option(this->path, "server");
     
     bool optExists = option.exists();
@@ -221,7 +225,7 @@ mcsm::Result mcsm::ServerOption::create(const std::string& name, mcsm::JvmOption
     mcsm::Result res6 = option.setValue("server_build", "latest");
     if(!res6.isSuccess()) return res6;
 
-    mcsm::Result res10 = option.setValue("auto_update", true);
+    mcsm::Result res10 = option.setValue("auto_update", update);
     if(!res10.isSuccess()) return res10;
 
     mcsm::Result res7 = option.setValue("type", this->server->getTypeAsString());

--- a/src/data/options/server_option.cpp
+++ b/src/data/options/server_option.cpp
@@ -49,7 +49,7 @@ mcsm::ServerOption::ServerOption(const std::string& version, const std::string& 
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
 
     if(!exists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(path)});
         return;
     }
 
@@ -96,7 +96,7 @@ mcsm::ServerOption::ServerOption(const std::string& path){
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
 
     if(!exists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(path)});
         return;
     }
 
@@ -177,7 +177,7 @@ mcsm::Result mcsm::ServerOption::create(const std::string& name, mcsm::JvmOption
     }
 
     if(optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured(this->path)});
         return res;
     }
 
@@ -268,7 +268,7 @@ mcsm::Result mcsm::ServerOption::start(mcsm::JvmOption& option, const std::strin
     }
 
     if(!fileExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(optionPath)});
         return res;
     }
 
@@ -324,7 +324,7 @@ mcsm::Result mcsm::ServerOption::update(const std::string& /* path */, const std
     }
 
     if(!fileExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(optionPath)});
         return res;
     }
 
@@ -359,7 +359,7 @@ std::unique_ptr<mcsm::JvmOption> mcsm::ServerOption::getDefaultOption() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return nullptr;
     }
 
@@ -454,7 +454,7 @@ std::string mcsm::ServerOption::getServerName() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -484,7 +484,7 @@ std::string mcsm::ServerOption::getServerVersion() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -514,7 +514,7 @@ std::string mcsm::ServerOption::getServerType() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -539,7 +539,7 @@ std::string mcsm::ServerOption::getServerJarFile() const{
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -569,7 +569,7 @@ std::string mcsm::ServerOption::getServerJarBuild() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 
@@ -599,7 +599,7 @@ bool mcsm::ServerOption::doesAutoUpdate() const {
     bool optExists = option.exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(!optExists){
-        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured(this->path)});
         return "";
     }
 

--- a/src/data/options/server_option.cpp
+++ b/src/data/options/server_option.cpp
@@ -345,6 +345,10 @@ bool mcsm::ServerOption::exists(){
     return rt;
 }
 
+std::string mcsm::ServerOption::getOptionPath() const {
+    return this->path;
+}
+
 std::unique_ptr<mcsm::JvmOption> mcsm::ServerOption::getDefaultOption() const {
     mcsm::Option option(this->path, "server");
     bool optExists = option.exists();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #include <mcsm/init.h>
 
-const std::string version = "0.1.1.2";
+const std::string version = "0.1.1.3";
 
 int main(int argc, char *argv[]){
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]){
         return 0;
     }
 
-    //If arguments exist, iterates through CommandManager::getCommands()
+    //Iterates through CommandManager::getCommands() only if argc is more than 1
     for(auto& v : mcsm::CommandManager::getCommands()){
         if(argv[1] == v->getName() || v->hasAlias(argv[1])){
             std::vector<std::string> args;
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]){
         }
     }
 
-    //If arguments exist but command is not found, prints message and exits
+    //Exit if unknown command detected.
     if(!commandFound){
         std::cerr << "Unknown command \"" << argv[1] << "\". " << "Type \'mcsm help\' for a list of commands.\n";
         return 1;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -67,6 +67,17 @@ mcsm::Result mcsm::Server::start(mcsm::JvmOption& option, const std::string& /* 
 
     std::string command = jPath + jvmOpt + optionPath + "/" + jar + svrOpt;
     mcsm::info("Running command : " + command);
+    
+    std::error_code ec;
+    std::filesystem::current_path(optionPath, ec);
+    if(ec){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "Server starting failed : " + ec.message(),
+            "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you believe that this is a software issue."
+        }});
+        return res;
+    }
+
     int result = mcsm::runCommand(command.c_str());
     if(result != 0){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {

--- a/src/server/server_generator.cpp
+++ b/src/server/server_generator.cpp
@@ -157,6 +157,7 @@ mcsm::Result mcsm::server::generateFabric(const std::string& name, mcsm::JvmOpti
     mcsm::info("Server type : " + type);
     mcsm::info("Server version : " + sVersion);
     mcsm::info("Server JVM launch profile : " + profile);
+    if(!autoUpdate) mcsm::info("Automatic updates : disabled");
 
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return res;
@@ -219,6 +220,7 @@ mcsm::Result mcsm::server::configure(std::unique_ptr<mcsm::ServerOption> serverO
     mcsm::info("Server type : " + type);
     mcsm::info("Server version : " + sVersion);
     mcsm::info("Server JVM launch profile : " + profile);
+    if(!autoUpdate) mcsm::info("Automatic updates : disabled");
 
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return res;

--- a/src/server/server_generator.cpp
+++ b/src/server/server_generator.cpp
@@ -21,7 +21,7 @@ SOFTWARE.
 */
 #include <mcsm/server/server_generator.h>
 
-mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOption& option, const std::string& version, const mcsm::BukkitServerType& type){
+mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOption& option, const std::string& version, const mcsm::BukkitServerType& type, const bool& autoUpdate){
     switch(type){
         case mcsm::BukkitServerType::PAPER: {
             std::shared_ptr<mcsm::PaperServer> server = std::make_shared<mcsm::PaperServer>();
@@ -41,7 +41,7 @@ mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOpti
                 mcsm::Result res(resp.first, resp.second);
                 return res;
             }
-            return configure(std::move(serverOption), name, option);
+            return configure(std::move(serverOption), name, option, autoUpdate);
         }
         case mcsm::BukkitServerType::PURPUR: {
             std::shared_ptr<mcsm::PurpurServer> server = std::make_shared<mcsm::PurpurServer>();
@@ -61,7 +61,7 @@ mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOpti
                 mcsm::Result res(resp.first, resp.second);
                 return res;
             }
-            return configure(std::move(serverOption), name, option);
+            return configure(std::move(serverOption), name, option, autoUpdate);
         }
         default: {
             mcsm::Result res({mcsm::ResultType::MCSM_WARN, {"This kind of Bukkit-API based server implementation is not supported right now."}});
@@ -72,7 +72,7 @@ mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOpti
     return res;
 }
 
-mcsm::Result mcsm::server::generateVanilla(const std::string& name, mcsm::JvmOption& option, const std::string& version){
+mcsm::Result mcsm::server::generateVanilla(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate){
     std::shared_ptr<mcsm::VanillaServer> server = std::make_shared<mcsm::VanillaServer>();
     bool vExists = server->hasVersion(version);
     if(!vExists){
@@ -85,15 +85,15 @@ mcsm::Result mcsm::server::generateVanilla(const std::string& name, mcsm::JvmOpt
         mcsm::Result res(resp.first, resp.second);
         return res;
     }
-    return configure(std::move(serverOption), name, option);
+    return configure(std::move(serverOption), name, option, autoUpdate);
 }
 
-mcsm::Result mcsm::server::generateForge(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* version */){
+mcsm::Result mcsm::server::generateForge(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* version */, const bool& /* autoUpdate */){
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return res;
 }
 
-mcsm::Result mcsm::server::generateFabric(const std::string& name, mcsm::JvmOption& option, const std::string& version){
+mcsm::Result mcsm::server::generateFabric(const std::string& name, mcsm::JvmOption& option, const std::string& version, const bool& autoUpdate){
     std::shared_ptr<mcsm::FabricServer> server = std::make_shared<mcsm::FabricServer>();
     bool vExists = server->hasVersion(version);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
@@ -121,7 +121,7 @@ mcsm::Result mcsm::server::generateFabric(const std::string& name, mcsm::JvmOpti
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
         return res;
     }
-    mcsm::Result sRes = serverOption->create(name, option);
+    mcsm::Result sRes = serverOption->create(name, option, autoUpdate);
     if(!sRes.isSuccess()) return sRes;
 
     std::string sName = serverOption->getServerName();
@@ -162,17 +162,17 @@ mcsm::Result mcsm::server::generateFabric(const std::string& name, mcsm::JvmOpti
     return res;
 }
 
-mcsm::Result mcsm::server::generateSponge(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* version */){
+mcsm::Result mcsm::server::generateSponge(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* version */, const bool& /* autoUpdate */){
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return res;
 }
 
-mcsm::Result mcsm::server::generateCustom(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* filePath */, const std::string& /* version */){
+mcsm::Result mcsm::server::generateCustom(const std::string& /* name */, mcsm::JvmOption& /* option */, const std::string& /* filePath */, const std::string& /* version */, const bool& /* autoUpdate */){
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
     return res;
 }
 
-mcsm::Result mcsm::server::configure(std::unique_ptr<mcsm::ServerOption> serverOption, const std::string& name, mcsm::JvmOption& option){
+mcsm::Result mcsm::server::configure(std::unique_ptr<mcsm::ServerOption> serverOption, const std::string& name, mcsm::JvmOption& option, const bool& autoUpdate){
     bool sExists = serverOption->exists();
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
@@ -183,7 +183,7 @@ mcsm::Result mcsm::server::configure(std::unique_ptr<mcsm::ServerOption> serverO
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverAlreadyConfigured()});
         return res;
     }
-    mcsm::Result sRes = serverOption->create(name, option);
+    mcsm::Result sRes = serverOption->create(name, option, autoUpdate);
     if(!sRes.isSuccess()) return sRes;
 
     std::string sName = serverOption->getServerName();

--- a/src/server/server_generator.cpp
+++ b/src/server/server_generator.cpp
@@ -74,11 +74,6 @@ mcsm::Result mcsm::server::generateBukkit(const std::string& name, mcsm::JvmOpti
 
 mcsm::Result mcsm::server::generateVanilla(const std::string& name, mcsm::JvmOption& option, const std::string& version){
     std::shared_ptr<mcsm::VanillaServer> server = std::make_shared<mcsm::VanillaServer>();
-    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
-        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
-        mcsm::Result res(resp.first, resp.second);
-        return res;
-    }
     bool vExists = server->hasVersion(version);
     if(!vExists){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverUnsupportedVersion()});

--- a/src/server/server_generator.cpp
+++ b/src/server/server_generator.cpp
@@ -239,7 +239,7 @@ std::shared_ptr<mcsm::Server> mcsm::server::detectServerType(const std::string& 
     }
     if(server == "vanilla"){
         sPtr = std::make_shared<mcsm::VanillaServer>();
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
+        //if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return nullptr;
     }
     if(server == "fabric" || server == "fabricmc"){
         sPtr = std::make_shared<mcsm::FabricServer>();

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -1,16 +1,7 @@
 #include <mcsm/server/type/custom_server.h>
 
-mcsm::CustomServer::CustomServer(const std::string& dir){
-    bool exists = mcsm::fileExists(dir);
-    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
-    if(!exists){
-        mcsm::Result res({
-            mcsm::ResultType::MCSM_WARN,
-            { "Working directory not found.", "Report this to Github (https://github.com/dodoman8067/mcsm) if you believe that this is an issue." }  
-        });
-        return;
-    }
-    this->directory = dir;
+mcsm::CustomServer::CustomServer(){
+
 }
 
 mcsm::CustomServer::~CustomServer(){
@@ -29,47 +20,82 @@ std::string mcsm::CustomServer::getSupportedVersions() const {
     return "unknown";
 }
 
-std::string mcsm::CustomServer::getFileLocation() const {
-    mcsm::Option option(".", "server");
-    if(!option.exists()){
-        mcsm::error("Option does not exist; Task aborted.");
-        std::exit(1);
+std::string mcsm::CustomServer::getFileLocation(const std::string& optionPath) const {
+    mcsm::Option option(optionPath, "server");
+    bool exists = option.exists();
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
+    if(!exists){
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::serverNotConfigured()});
+        return "";
     }
     if(option.getValue("jar_location") == nullptr){
-        mcsm::error("No \"jar_location\" value specified in file " + option.getName());
-        mcsm::error("Manually editing the launch profile might have caused this issue.");
-        mcsm::error("If you know what you're doing, I believe you that you know how to handle this issue.");
-        mcsm::error("Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue.");
-        std::exit(1);
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonNotFound("\"jar_location\"", "server.json")});
+        return "";
     }
     if(!option.getValue("jar_location").is_string()){
-        mcsm::error("Value \"jar_location\" has to be a string, but it's not.");
-        mcsm::error("Manually editing the launch profile might have caused this issue.");
-        mcsm::error("If you know what you're doing, I believe you that you know how to handle this issue.");
-        mcsm::error("Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue.");
-        std::exit(1);
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, mcsm::message_utils::jsonWrongType("\"jar_location\"", "string")});
+        return "";
     }
     std::string value = option.getValue("jar_location");
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return "";
     if(mcsm::startsWith(value, "current") && mcsm::endsWith(value, "current")){
         return mcsm::getCurrentPath();
     }
-    return option.getValue("jar_location");
+    return value;
 }
 
-mcsm::Result mcsm::CustomServer::setFileLocation(const std::string& location) {
+mcsm::Result mcsm::CustomServer::setFileLocation(const std::string& optionPath, const std::string& location) {
     mcsm::Option option(".", "server");
     return option.setValue("jar_location", location);
 }
 
-mcsm::Result mcsm::CustomServer::getFileFromLocation() {
-    std::string location = getFileLocation();
-    if(isFile(location) || isURL(location)){
+mcsm::Result mcsm::CustomServer::getFileFromLocation(const std::string& optionPath){
+    std::string location = getFileLocation(optionPath);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    bool isFileOrURL = isFile(location) || isURL(location);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    bool file = isFile(location);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+        std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+        mcsm::Result res(resp.first, resp.second);
+        return res;
+    }
+
+    if(isFileOrURL){
         if(isURL(location)){
-            mcsm::download(getJarFile(), location, getFileLocation(), true);
+            std::string jar = getJarFile(optionPath);
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+            std::string loc = getFileLocation(optionPath);
+            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+                mcsm::Result res(resp.first, resp.second);
+                return res;
+            }
+            return mcsm::download(jar, location, loc, true);
+        }
+        if(file){
+            // TODO : Copy file
         }
     }else{
-        mcsm::error("The following server jarfile location wasn't a vaild location : " + location);
-        mcsm::error("Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue.");
+        mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
+            "The following server jarfile wasn't located in the vaild location : " + location,
+            "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
+        }});
+        return res;
     }
 
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});
@@ -77,7 +103,7 @@ mcsm::Result mcsm::CustomServer::getFileFromLocation() {
 }
 
 bool mcsm::CustomServer::isFile(const std::string& location) const {
-    return std::filesystem::exists(location);
+    return mcsm::fileExists(location);
 }
 
 bool mcsm::CustomServer::isURL(const std::string& location) const {

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -93,7 +93,7 @@ mcsm::Result mcsm::CustomServer::setupServerJarFile(const std::string& optionPat
             "The following server jarfile wasn't located in the vaild location : " + location,
             "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
         }});
-        return res;   
+        return res;
     }
 
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2023 dodoman8067
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include <mcsm/server/type/custom_server.h>
 
 mcsm::CustomServer::CustomServer(){

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -49,7 +49,7 @@ mcsm::Result mcsm::CustomServer::setFileLocation(const std::string& optionPath, 
     return option.setValue("jar_location", location);
 }
 
-mcsm::Result mcsm::CustomServer::getFileFromLocation(const std::string& optionPath){
+mcsm::Result mcsm::CustomServer::setupServerJarFile(const std::string& optionPath){
     std::string location = getFileLocation(optionPath);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
@@ -57,7 +57,7 @@ mcsm::Result mcsm::CustomServer::getFileFromLocation(const std::string& optionPa
         return res;
     }
 
-    bool isFileOrURL = isFile(location) || isURL(location);
+    bool url = isURL(location);
     if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
         std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
         mcsm::Result res(resp.first, resp.second);
@@ -71,31 +71,29 @@ mcsm::Result mcsm::CustomServer::getFileFromLocation(const std::string& optionPa
         return res;
     }
 
-    if(isFileOrURL){
-        if(isURL(location)){
-            std::string jar = getJarFile(optionPath);
-            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
-                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
-                mcsm::Result res(resp.first, resp.second);
-                return res;
-            }
-            std::string loc = getFileLocation(optionPath);
-            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
-                std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
-                mcsm::Result res(resp.first, resp.second);
-                return res;
-            }
-            return mcsm::download(jar, location, loc, true);
+    
+    if(url){
+        std::string jar = getJarFile(optionPath);
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
         }
-        if(file){
-            // TODO : Copy file
+        std::string loc = getFileLocation(optionPath);
+        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
+            std::pair<mcsm::ResultType, std::vector<std::string>> resp = mcsm::getLastResult();
+            mcsm::Result res(resp.first, resp.second);
+            return res;
         }
+        return mcsm::download(jar, location, loc, true);
+    }else if(file){
+        // TODO : Copy file
     }else{
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
             "The following server jarfile wasn't located in the vaild location : " + location,
             "Please report this to GitHub (https://github.com/dodoman8067/mcsm) if you think this is a software issue."
         }});
-        return res;
+        return res;   
     }
 
     mcsm::Result res({mcsm::ResultType::MCSM_SUCCESS, {"Success"}});

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -1,9 +1,16 @@
 #include <mcsm/server/type/custom_server.h>
 
-// Currently unmaintained file.
-
-mcsm::CustomServer::CustomServer(){
-
+mcsm::CustomServer::CustomServer(const std::string& dir){
+    bool exists = mcsm::fileExists(dir);
+    if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS) return;
+    if(!exists){
+        mcsm::Result res({
+            mcsm::ResultType::MCSM_WARN,
+            { "Working directory not found.", "Report this to Github (https://github.com/dodoman8067/mcsm) if you believe that this is an issue." }  
+        });
+        return;
+    }
+    this->directory = dir;
 }
 
 mcsm::CustomServer::~CustomServer(){

--- a/src/util/cli/result.cpp
+++ b/src/util/cli/result.cpp
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #include <mcsm/util/cli/result.h>
 
+static std::mutex res_mutex;
 static std::pair<mcsm::ResultType, std::vector<std::string>> res = {mcsm::ResultType::MCSM_SUCCESS, { "Not updated" }};
 
 mcsm::Result::Result(const mcsm::ResultType& type, const std::vector<std::string>& message){
@@ -56,52 +57,40 @@ void mcsm::Result::printMessage(){
 }
 
 void mcsm::Result::printMessage(const mcsm::ResultType& type){
-    switch (type){
-        case mcsm::ResultType::MCSM_SUCCESS:
-            for(const std::string& str : message){
-                mcsm::success(str);
-            }
-            break;          
-        case mcsm::ResultType::MCSM_OK:
-            for(const std::string& str : message){
+    std::vector<std::string> message = this->message;
+
+    for(const auto& str : message){
+        switch (type){
+            case mcsm::ResultType::MCSM_SUCCESS:
+            case mcsm::ResultType::MCSM_OK:
                 mcsm::info(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_WARN:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_WARN:
+            case mcsm::ResultType::MCSM_WARN_NOEXIT:
                 mcsm::warning(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_WARN_NOEXIT:
-            for(const std::string& str : message){
-                mcsm::warning(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_FAIL:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_FAIL:
                 mcsm::error(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_UNKNOWN:
-            for(const std::string& str : message){
-                mcsm::warning(str);
-            }
-            break;
-        default:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_UNKNOWN:
+            default:
                 mcsm::error(str);
-            }
-            mcsm::error("FATAL : Unknown usage of mcsm::ResultType detected. Please report this to GitHub. (https://github.com/dodoman8067/mcsm)");
-            break;    
+                mcsm::error("FATAL : Unknown usage of mcsm::ResultType detected. Please report this to GitHub. (https://github.com/dodoman8067/mcsm)");
+                break;
+        }
     }
 }
 
 std::pair<mcsm::ResultType, std::vector<std::string>> mcsm::getLastResult(){
+    std::lock_guard<std::mutex> lock(res_mutex);
     return res;
 }
 
 void mcsm::updateLastResult(const std::pair<mcsm::ResultType, std::vector<std::string>> newRes){
-    res = newRes;
+    std::lock_guard<std::mutex> lock(res_mutex);
+    if(res != newRes){
+        res = newRes;
+    }
 }
 
 void mcsm::printResultMessage(){
@@ -111,42 +100,25 @@ void mcsm::printResultMessage(){
 void mcsm::printResultMessage(const std::pair<mcsm::ResultType, std::vector<std::string>> res){
     mcsm::ResultType type = res.first;
     std::vector<std::string> message = res.second;
-    switch (type){
-        case mcsm::ResultType::MCSM_SUCCESS:
-            for(const std::string& str : message){
-                mcsm::success(str);
-            }
-            break;            
-        case mcsm::ResultType::MCSM_OK:
-            for(const std::string& str : message){
+
+    for(const auto& str : message){
+        switch (type){
+            case mcsm::ResultType::MCSM_SUCCESS:
+            case mcsm::ResultType::MCSM_OK:
                 mcsm::info(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_WARN:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_WARN:
+            case mcsm::ResultType::MCSM_WARN_NOEXIT:
                 mcsm::warning(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_WARN_NOEXIT:
-            for(const std::string& str : message){
-                mcsm::warning(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_FAIL:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_FAIL:
                 mcsm::error(str);
-            }
-            break;
-        case mcsm::ResultType::MCSM_UNKNOWN:
-            for(const std::string& str : message){
-                mcsm::warning(str);
-            }
-            break;
-        default:
-            for(const std::string& str : message){
+                break;
+            case mcsm::ResultType::MCSM_UNKNOWN:
+            default:
                 mcsm::error(str);
-            }
-            mcsm::error("FATAL : Unknown usage of mcsm::ResultType detected. Please report this to GitHub. (https://github.com/dodoman8067/mcsm)");
-            break;    
+                mcsm::error("FATAL : Unknown usage of mcsm::ResultType detected. Please report this to GitHub. (https://github.com/dodoman8067/mcsm)");
+                break;
+        }
     }
 }

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -30,7 +30,7 @@ bool mcsm::startsWith(const std::string& str, const std::string& value){
 
 bool mcsm::endsWith(const std::string& str, const std::string& value){
     // Ensure that `value` is not longer than `str` to avoid out-of-bounds comparisons
-    if (str.length() < value.length()) {
+    if(str.length() < value.length()){
         return false;
     }
     return str.compare(str.length() - value.length(), value.length(), value) == 0;
@@ -38,7 +38,7 @@ bool mcsm::endsWith(const std::string& str, const std::string& value){
 
 bool mcsm::isWhitespaceOrEmpty(const std::string& str){
     // If the string is empty, consider it whitespace
-    if (str.empty()) {
+    if(str.empty()){
         return true;
     }
     // Check if the string has only whitespace characters
@@ -48,8 +48,18 @@ bool mcsm::isWhitespaceOrEmpty(const std::string& str){
 void mcsm::replaceAll(std::string& str, const std::string& value, const std::string& replacement){
     std::string::size_type pos = 0;
     // Iterate through the string and replace all occurrences of `value`
-    while ((pos = str.find(value, pos)) != std::string::npos) {
+    while((pos = str.find(value, pos)) != std::string::npos){
         str.replace(pos, value.length(), replacement);
         pos += replacement.length();
     }
+}
+
+std::string mcsm::safeString(const std::string& str){
+    std::string value = str;
+    mcsm::replaceAll(value, "&", "_");
+    mcsm::replaceAll(value, "|", "_");
+    mcsm::replaceAll(value, "\\", "_");
+    mcsm::replaceAll(value, "..", "__");
+    mcsm::replaceAll(value, "/", "_");
+    return value;
 }


### PR DESCRIPTION
* Add `auto_update` option in server configuration files; set this to true to enable automatic server jarfile update checking.
* Display the current working path in server configuration related error messages.
* Internal changes
  * Add `MultiServerOption` and `CustomServer` classes which cannot be accessed from command line interface. 
  * Use references instead of `std::unique_ptr` in some functions.
  * Do not update `std::pair` in `Result` if it has same code and message.
  * Implement several optimizations and bug fixes.