### PR TITLE
0.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,12 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+
 # Set compiler options
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -DMCSM_NLOHMANN_VER=\\\"${nlohmann_json_VERSION}\\\"")
     set(CMAKE_CXX_FLAGS_DEBUG "-g -DMCSM_DEBUG")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffunction-sections -fdata-sections")
 endif()
 
 if(BUILD_STATIC_EXE)
@@ -64,7 +65,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 endif()
 
 # Add executable
@@ -72,6 +74,22 @@ if(LINUX AND CMAKE_BUILD_TYPE MATCHES Debug)
     add_executable(mcsm ${SRC_FILES} ${RESOURCE_FILE} backward/backward.cpp)
 else()
     add_executable(mcsm ${SRC_FILES} ${RESOURCE_FILE})
+endif()
+
+# --- Post-build: strip (only in Release) ---
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    if(MINGW)
+        find_program(STRIP_TOOL NAMES strip.exe)
+    elseif(UNIX)
+        find_program(STRIP_TOOL NAMES strip)
+    endif()
+
+    if(STRIP_TOOL)
+        add_custom_command(TARGET mcsm POST_BUILD
+            COMMAND ${STRIP_TOOL} $<TARGET_FILE:mcsm>
+            COMMENT "Stripping symbols to reduce binary size"
+        )
+    endif()
 endif()
 
 # Link dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
     endif()
 
     if(STRIP_TOOL)
+        message("-- Found strip: ${STRIP_TOOL}")
         add_custom_command(TARGET mcsm POST_BUILD
             COMMAND ${STRIP_TOOL} $<TARGET_FILE:mcsm>
             COMMENT "Stripping symbols to reduce binary size"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Find dependencies 
-find_package(termcolor REQUIRED)
 find_package(CURL REQUIRED CONFIG)
 find_package(nlohmann_json REQUIRED)
 include(Findlibgit2)
@@ -96,7 +95,6 @@ endif()
 # Link dependencies
 target_link_libraries(mcsm PRIVATE CURL::libcurl)
 target_link_libraries(mcsm PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(mcsm PRIVATE termcolor::termcolor)
 
 # Some dependencies for libgit2 in Windows
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This project uses the following dependencies :
 * [cURL](https://github.com/curl/curl)
 * [libgit2](https://github.com/libgit2/libgit2)
 * [nlohmann/json](https://github.com/nlohmann/json)
-* [termcolor](https://github.com/ikalnytskyi/termcolor)
 * [backward-cpp](https://github.com/bombela/backward-cpp) (DEBUG)
 
 ## Usage
@@ -39,5 +38,4 @@ This project is under [MIT](LICENSE) license.
 * [cURL](https://curl.se/docs/copyright.html)
 * [libgit2](https://github.com/libgit2/libgit2/blob/main/COPYING)
 * [nlohmann/json](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT)
-* [termcolor](https://github.com/ikalnytskyi/termcolor/LICENSE)
 * [backward-cpp](https://github.com/bombela/backward-cpp/blob/master/LICENSE.txt)

--- a/include/mcsm/command/server/start_server_command.h
+++ b/include/mcsm/command/server/start_server_command.h
@@ -37,7 +37,8 @@ namespace mcsm {
         mcsm::SearchTarget getSearchTarget(const std::vector<std::string>& args);
         std::unique_ptr<mcsm::JvmOption> searchOption(const std::vector<std::string>& args, mcsm::ServerConfigLoader* loader);
         std::unique_ptr<mcsm::JvmOption> searchOption(const mcsm::SearchTarget& target, const std::string& name);
-        void detectServer(const std::vector<std::string>& args);
+        std::string getServerPath(const std::vector<std::string> &args);
+        void detectServer(const std::vector<std::string> &args);
         inline bool isConfigured();
     public:
         StartServerCommand(const std::string& name, const std::string& description);

--- a/include/mcsm/http/download.h
+++ b/include/mcsm/http/download.h
@@ -24,9 +24,8 @@ SOFTWARE.
 #ifndef __MCSM_DOWNLOAD_H__
 #define __MCSM_DOWNLOAD_H__
 
-#include <curl/curl.h>
-#include <mcsm/util/cli/logging.h>
 #include <mcsm/http/holder.h>
+#include <mcsm/util/cli/logging.h>
 #include <mcsm/util/cli/cli_utils.h>
 #include <cstdio>
 #include <filesystem>

--- a/include/mcsm/http/holder.h
+++ b/include/mcsm/http/holder.h
@@ -1,6 +1,12 @@
 #ifndef __MCSM_HOLDER_H__
 #define __MCSM_HOLDER_H__
 
+#include <cstring>
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+    #include <windows.h>
+#endif
 #include <curl/curl.h>
 #include <mcsm/util/cli/result.h>
 

--- a/include/mcsm/util/cli/cli_utils.h
+++ b/include/mcsm/util/cli/cli_utils.h
@@ -32,6 +32,7 @@ SOFTWARE.
 #include <mcsm/util/cli/result.h>
 #include <mcsm/util/cli/logging.h>
 #include <any>
+#include <climits>
 #ifdef __linux__
     #include <sys/wait.h>
 #endif

--- a/include/mcsm/util/cli/logging.h
+++ b/include/mcsm/util/cli/logging.h
@@ -24,14 +24,7 @@ SOFTWARE.
 #define __MCSM_LOGGING_H__
 
 #include <mcsm/util/string_utils.h>
-/*
- I know this file does not use libcurl functions.
- But the files that include this header does, and that causes windows header issue(winsock2.h included before windows.h)
-*/
-#include <curl/curl.h>
-#ifdef CURLINC_CURL_H
-    #include <termcolor/termcolor.hpp>
-#endif
+#include <mcsm/util/cli/text_color.h>
 
 namespace mcsm {
     extern bool log; // means defined elsewhere
@@ -59,7 +52,9 @@ namespace mcsm {
         if(!log) return;
         std::string msg = message;
         if(!mcsm::endsWith(msg, "\n")) msg += "\n";
-        std::cout << termcolor::bright_green << "[mcsm/INFO] " << msg << termcolor::reset;
+        mcsm::setcol(mcsm::TextColor::GREEN);
+        std::cout << "[mcsm/INFO] " << msg;
+        mcsm::setcol(mcsm::TextColor::RESET);
     }
 
     /**
@@ -70,7 +65,9 @@ namespace mcsm {
         if(!log) return;
         std::string msg = message;
         if(!mcsm::endsWith(msg, "\n")) msg += "\n";
-        std::cerr << termcolor::bright_yellow << "[mcsm/WARN] " << msg << termcolor::reset;
+        mcsm::setcol(mcsm::TextColor::BRIGHT_YELLOW);
+        std::cerr << "[mcsm/WARN] " << msg;
+        mcsm::setcol(mcsm::TextColor::RESET);
     }
 
     /**
@@ -81,7 +78,9 @@ namespace mcsm {
         if(!log) return;
         std::string msg = message;
         if(!mcsm::endsWith(msg, "\n")) msg += "\n";
-        std::cerr << termcolor::bright_red << "[mcsm/ERROR] " << msg << termcolor::reset;
+        mcsm::setcol(mcsm::TextColor::RED);
+        std::cerr << "[mcsm/ERROR] " << msg;
+        mcsm::setcol(mcsm::TextColor::RESET);
     }
 }
 

--- a/include/mcsm/util/cli/result.h
+++ b/include/mcsm/util/cli/result.h
@@ -25,7 +25,6 @@ SOFTWARE.
 
 #include <vector>
 #include <mutex>
-#include <mcsm/util/cli/logging.h>
 
 namespace mcsm {
     enum class ResultType {

--- a/include/mcsm/util/cli/result.h
+++ b/include/mcsm/util/cli/result.h
@@ -25,6 +25,7 @@ SOFTWARE.
 
 #include <vector>
 #include <mutex>
+#include <string>
 
 namespace mcsm {
     enum class ResultType {

--- a/include/mcsm/util/cli/text_color.h
+++ b/include/mcsm/util/cli/text_color.h
@@ -1,0 +1,51 @@
+#ifndef __MCSM_TEXT_COLOR_H__
+#define __MCSM_TEXT_COLOR_H__
+
+#include <iostream>
+
+namespace mcsm {
+    enum class TextColor {
+        RESET,
+        RED,
+        DARK_RED,
+        YELLOW,
+        BRIGHT_YELLOW,
+        GREEN,
+        BLUE
+    };
+    
+    #ifdef _WIN32
+    #include <windows.h>
+    inline void setcol(TextColor color) {
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        WORD attr = 0;
+    
+        switch (color) {
+            case TextColor::RED:      attr = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
+            case TextColor::DARK_RED:  attr = FOREGROUND_RED; break;
+            case TextColor::YELLOW:   attr = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
+            case TextColor::GREEN:    attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
+            case TextColor::BRIGHT_YELLOW: attr = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
+            case TextColor::BLUE:     attr = FOREGROUND_BLUE | FOREGROUND_INTENSITY; break;
+            case TextColor::RESET:    attr = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE; break;
+        }
+        SetConsoleTextAttribute(hConsole, attr);
+    }
+    #else
+    inline void setcol(TextColor color) {
+        const char* code = "";
+        switch (color) {
+            case TextColor::RED:     code = "\033[91m"; break;  // Bright red
+            case TextColor::DARK_RED: code = "\033[31m"; break;  // Normal red
+            case TextColor::YELLOW:  code = "\033[33m"; break;
+            case TextColor::BRIGHT_YELLOW: code = "\033[93m"; break;
+            case TextColor::GREEN:   code = "\033[32m"; break;
+            case TextColor::BLUE:    code = "\033[34m"; break;
+            case TextColor::RESET:   code = "\033[0m";  break;
+        }
+        std::cout << code;
+    }
+    #endif
+}
+
+#endif // __MCSM_TEXT_COLOR_H__

--- a/include/mcsm/util/cli/text_color.h
+++ b/include/mcsm/util/cli/text_color.h
@@ -2,6 +2,7 @@
 #define __MCSM_TEXT_COLOR_H__
 
 #include <iostream>
+#include <mcsm/http/holder.h> // have to include this to avoid winsock issues in mingw
 
 namespace mcsm {
     enum class TextColor {
@@ -15,7 +16,6 @@ namespace mcsm {
     };
     
     #ifdef _WIN32
-    #include <windows.h>
     inline void setcol(TextColor color) {
         HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
         WORD attr = 0;

--- a/src/command/command_manager.cpp
+++ b/src/command/command_manager.cpp
@@ -54,7 +54,7 @@ void mcsm::CommandManager::cleanup(){
 
 void mcsm::CommandManager::addCommand(std::unique_ptr<mcsm::Command> command){
     if(hasCommand(command->getName())) return;
-   commands->push_back(std::move(command));
+    commands->push_back(std::move(command));
 }
 
 const std::vector<std::unique_ptr<mcsm::Command>>& mcsm::CommandManager::getCommands(){

--- a/src/command/server/group/subcommands/list.cpp
+++ b/src/command/server/group/subcommands/list.cpp
@@ -57,7 +57,9 @@ void mcsm::GroupListSubCommand::execute(const std::vector<std::string>& args){
     }else{
         for(auto& [serverstr, isRunning] : strmap){
             if(isRunning){
-                std::cout << termcolor::green << " * " + serverstr + " (running)" << termcolor::reset << "\n";
+                mcsm::setcol(mcsm::TextColor::GREEN);
+                std::cout << " * " + serverstr + " (running)\n";
+                mcsm::setcol(mcsm::TextColor::RESET);
             }else{
                 std::cout << " * " + serverstr << "\n";
             }

--- a/src/command/util/version_command.cpp
+++ b/src/command/util/version_command.cpp
@@ -31,7 +31,11 @@ mcsm::VersionCommand::~VersionCommand(){
 }
 
 void mcsm::VersionCommand::execute(const std::vector<std::string>& /* args */){
-    std::cout << "MCSM version : " << version << "\n";
+    #ifdef MCSM_DEBUG
+        std::cout << "MCSM version : " << version << " (DEBUG)\n";
+    #else
+        std::cout << "MCSM version : " << version << "\n";
+    #endif
     std::cout << "cURL version : " << curl_version() << "\n";
     #ifdef MCSM_NLOHMANN_VER
         std::cout << "nlohmann::json version : " << MCSM_NLOHMANN_VER << "\n";

--- a/src/data/options/server_config_loader.cpp
+++ b/src/data/options/server_config_loader.cpp
@@ -247,7 +247,7 @@ std::unique_ptr<mcsm::JvmOption> mcsm::ServerConfigLoader::getDefaultOption() co
         }});
         return nullptr;
     }
-    std::unique_ptr<mcsm::JvmOption> jvmOption = std::make_unique<mcsm::JvmOption>(profileObj["name"], target);
+    std::unique_ptr<mcsm::JvmOption> jvmOption = std::make_unique<mcsm::JvmOption>(profileObj["name"], target, this->configPath);
     if(!jvmOption->exists() || jvmOption == nullptr){
         mcsm::Result res({mcsm::ResultType::MCSM_FAIL, {
             "Invalid default launch profile.",

--- a/src/http/download.cpp
+++ b/src/http/download.cpp
@@ -36,6 +36,17 @@ static int progressCallback(void * /* clientp */, curl_off_t dltotal, curl_off_t
         double percentage = static_cast<double>(dlnow) / static_cast<double>(dltotal) * 100.0;
         int progress = static_cast<int>(barWidth * percentage / 100.0);
 
+        if(progress < 4)
+            mcsm::setcol(mcsm::TextColor::DARK_RED);
+        else if(progress < 10)
+            mcsm::setcol(mcsm::TextColor::RED);
+        else if(progress < 16)
+            mcsm::setcol(mcsm::TextColor::YELLOW);
+        else if(progress < 20)
+            mcsm::setcol(mcsm::TextColor::GREEN);
+        else
+            mcsm::setcol(mcsm::TextColor::BLUE);
+
         std::cout << "\r[";
         for(int i = 0; i < barWidth; i++){
             if(i < progress) std::cout << "=";
@@ -45,6 +56,8 @@ static int progressCallback(void * /* clientp */, curl_off_t dltotal, curl_off_t
         std::cout << "] ";
         std::cout << std::fixed << std::setprecision(1) << percentage << "%";
         std::cout.flush();
+
+        mcsm::setcol(mcsm::TextColor::RESET);
     }
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,55 +26,8 @@ SOFTWARE.
 #include <mcsm/util/cli/signal_handler.h>
 #include <new>
 #include <thread>
-//#include <mcsm/data/options/multi_server_option.h>
 
-const std::string version = "0.5";
-
-/*
-#include <mcsm/util/cli/screen_session.h>
-
-void testScreenSession() {
-    mcsm::ScreenSession session("test", "./mcsm start");
-
-    // Test starting the session
-    auto startResult = session.start();
-    if (startResult.getResultPair().first == mcsm::ResultType::MCSM_SUCCESS) {
-        std::cout << "Session started successfully: " << session.getName() << std::endl;
-    } else {
-        std::cerr << "Failed to start session: " << startResult.getMessage()[0] << std::endl;
-        return;
-    }
-
-    // Test isRunning
-    if (session.isRunning()) {
-        std::cout << "Session is running: " << session.getFullSessionName() << std::endl;
-    } else {
-        std::cerr << "Session is not running after start." << std::endl;
-    }
-
-    // Test sending a command (this won't do much since sleep ignores input, but it's for testing)
-    auto sendResult = session.sendCommand("say Hello from ScreenSession");
-    if (sendResult.getResultPair().first == mcsm::ResultType::MCSM_SUCCESS) {
-        std::cout << "Command sent successfully to session: " << session.getFullSessionName() << std::endl;
-    } else {
-        std::cerr << "Failed to send command: " << sendResult.getMessage()[0] << std::endl;
-    }
-
-
-    while(1){
-    // Wait a few seconds to simulate activity
-    std::this_thread::sleep_for(std::chrono::seconds(20));
-
-    // Test isRunning after stop
-    if (!session.isRunning()) {
-        std::cout << "Session is no longer running: " << session.getFullSessionName() << std::endl;
-        break;
-    } else {
-        std::cerr << "Session is still running after stop!" << std::endl;
-    }
-    }
-}
-*/
+const std::string version = "0.5.1";
 
 int main(int argc, char *argv[]){
     std::set_new_handler(mcsm::signal_handler::new_handle);
@@ -113,17 +66,6 @@ int main(int argc, char *argv[]){
     if(argc < 2){
         std::cout << "Welcome to MCSM (Minecraft Server Manager).\n";
         std::cout << "Type \"mcsm help\" for a list of commands.\n";
-
-        //testScreenSession();
-
-        /*
-        mcsm::MultiServerOption a(mcsm::getCurrentPath());
-            if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_OK && mcsm::getLastResult().first != mcsm::ResultType::MCSM_SUCCESS){
-        mcsm::printResultMessage();
-        if(mcsm::getLastResult().first != mcsm::ResultType::MCSM_WARN_NOEXIT) std::exit(1);
-    }
-        a.start().printMessage();
-        */
         return 0;
     }
 

--- a/src/server/type/custom_server.cpp
+++ b/src/server/type/custom_server.cpp
@@ -291,8 +291,6 @@ bool mcsm::CustomServer::isFile(const std::string& location) const {
     return isRegularFile;
 }
 
-
-//TODO: Update regex. the program thinks url is a file rn
 bool mcsm::CustomServer::isURL(const std::string& location) const {
     std::regex urlPattern(
         R"(^https?://[0-9a-z\.-]+(:[1-9][0-9]*)?(/[^\s]*)*$)"

--- a/src/util/cli/result.cpp
+++ b/src/util/cli/result.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <mcsm/util/cli/logging.h>  // have to include this to avoid winsock issues in mingw
 #include <mcsm/util/cli/result.h>
 
 static std::mutex res_mutex;

--- a/src/util/cli/signal_handler.cpp
+++ b/src/util/cli/signal_handler.cpp
@@ -2,19 +2,20 @@
 #include <mcsm/command/command_manager.h>
 
 void mcsm::signal_handler::handle(int signal){
+    mcsm::setcol(mcsm::TextColor::DARK_RED);
     switch (signal){
         case SIGSEGV:
-            std::cerr << termcolor::red << "[mcsm/FATAL] Segmentation fault (SIGSEGV) encountered." << termcolor::reset << "\n";
+            std::cerr << "[mcsm/FATAL] Segmentation fault (SIGSEGV) encountered." << "\n";
             break;
         case SIGFPE:
-            std::cerr << termcolor::red << "[mcsm/FATAL] Floating point exception (SIGFPE) encountered." << termcolor::reset << std::endl;
+            std::cerr << "[mcsm/FATAL] Floating point exception (SIGFPE) encountered." << std::endl;
             break;
         case SIGILL:
-            std::cerr << termcolor::red << "[mcsm/FATAL] Illegal instruction (SIGILL) encountered." << termcolor::reset << std::endl;
+            std::cerr << "[mcsm/FATAL] Illegal instruction (SIGILL) encountered." << std::endl;
             break;
         #ifdef SIGBUS
             case SIGBUS:
-                std::cerr << termcolor::red << "[mcsm/FATAL] Bus error (SIGBUS) encountered." << termcolor::reset << std::endl;
+                std::cerr << "[mcsm/FATAL] Bus error (SIGBUS) encountered." << std::endl;
                 break;
         #endif
         case SIGTERM:
@@ -31,11 +32,15 @@ void mcsm::signal_handler::handle(int signal){
             std::exit(signal);
             break;
     }
-    std::cerr << termcolor::red << "[mcsm/FATAL] Signal: " << signal << termcolor::reset << "\n";
-    std::cerr << termcolor::red << "[mcsm/FATAL] Please report this to my Github (https://github.com/dodoman8067/mcsm) and explain how you encountered this error."<< termcolor::reset << "\n";
+    std::cerr << "[mcsm/FATAL] Signal: " << signal << "\n";
+    std::cerr << "[mcsm/FATAL] Please report this to my Github (https://github.com/dodoman8067/mcsm) and explain how you encountered this error.\n";
+    mcsm::setcol(mcsm::TextColor::RESET);
 
     #ifdef __linux__
-        std::cerr << termcolor::red << "[mcsm/FATAL] POSIX detected. Will try to print stacktrace."<< termcolor::reset << "\n";
+        mcsm::setcol(mcsm::TextColor::DARK_RED);
+        std::cerr << "[mcsm/FATAL] POSIX detected. Will try to print stacktrace.\n";
+        mcsm::setcol(mcsm::TextColor::RESET);
+        
         std::vector<void*> array(50);
         size_t size = backtrace(array.data(), array.size());
 
@@ -51,8 +56,10 @@ void mcsm::signal_handler::handle(int signal){
 }
 
 void mcsm::signal_handler::new_handle(){
-    std::cerr << termcolor::red << "[mcsm/FATAL] Memory allocation failed." << termcolor::reset << "\n";
-    std::cerr << termcolor::red << "[mcsm/FATAL] Make sure you have enough memory to have this program running." << termcolor::reset << "\n";
-    std::cerr << termcolor::red << "[mcsm/FATAL] Please report this to my Github (https://github.com/dodoman8067/mcsm) if you believe this is an error."<< termcolor::reset << "\n";
+    mcsm::setcol(mcsm::TextColor::DARK_RED);
+    std::cerr << "[mcsm/FATAL] Memory allocation failed.\n";
+    std::cerr << "[mcsm/FATAL] Make sure you have enough memory to have this program running.\n";
+    std::cerr << "[mcsm/FATAL] Please report this to my Github (https://github.com/dodoman8067/mcsm) if you believe this is an error.\n";
+    mcsm::setcol(mcsm::TextColor::RESET);
     std::abort();
 }


### PR DESCRIPTION
 * `mcsm::ServerConfigLoader` now searches current jvm option path in config file path
 * Color download progress bar during libcurl file downloads
 * Include stripping in cmake and adjust used compiler options for optimization
 * Support server load path location as  `--serverpath` option and fix undefined behavior on parsing java profiles in `start` command